### PR TITLE
Tighten Environment builder typing and wire GameRules into GameManager

### DIFF
--- a/chipiron/environments/chess/chess_rules.py
+++ b/chipiron/environments/chess/chess_rules.py
@@ -1,0 +1,116 @@
+"""
+Chess-specific rules adapter.
+"""
+
+from dataclasses import dataclass
+
+from atomheart.board import IBoard
+from valanga import Color
+from valanga.over_event import HowOver, Winner
+
+from chipiron.games.game.game_rules import (
+    GameOutcome,
+    GameRules,
+    OutcomeKind,
+    PositionAssessment,
+    VerdictKind,
+)
+from chipiron.players.boardevaluators.table_base.factory import AnySyzygyTable
+
+
+@dataclass(frozen=True)
+class ChessRules(GameRules[IBoard]):
+    syzygy: AnySyzygyTable | None = None
+
+    def outcome(self, state: IBoard) -> GameOutcome | None:
+        if state.is_game_over():
+            return self._outcome_from_board(state)
+        return None
+
+    def pretty_result(self, state: IBoard, outcome: GameOutcome) -> str:
+        result_str = self._result_string_outcome(outcome)
+        reason = outcome.reason
+        if reason is None and state.is_game_over():
+            reason = self._termination_reason(state)
+        message = f"Result: {result_str}"
+        if reason:
+            message = f"{message} ({reason})"
+        return message
+
+    def assessment(self, state: IBoard) -> PositionAssessment | None:
+        if self.syzygy is None or not self.syzygy.fast_in_table(state):
+            return None
+        winner, how_over = self.syzygy.get_over_event(board=state)
+        return self._assessment_from_over_event(winner, how_over, reason="syzygy")
+
+    def pretty_assessment(self, state: IBoard, assessment: PositionAssessment) -> str:
+        result_str = self._result_string_assessment(assessment)
+        message = f"Assessment: {result_str}"
+        if assessment.reason:
+            message = f"{message} ({assessment.reason})"
+        if self.syzygy is not None and self.syzygy.fast_in_table(state):
+            syzygy_str = self.syzygy.string_result(state)
+            message = f"{message} | Syzygy: {syzygy_str}"
+        return message
+
+    def _outcome_from_board(self, state: IBoard) -> GameOutcome:
+        result = state.result(claim_draw=True)
+        reason = self._termination_reason(state)
+        match result:
+            case "1-0":
+                return GameOutcome(kind=OutcomeKind.WIN, winner=Color.WHITE, reason=reason)
+            case "0-1":
+                return GameOutcome(kind=OutcomeKind.WIN, winner=Color.BLACK, reason=reason)
+            case "1/2-1/2":
+                return GameOutcome(kind=OutcomeKind.DRAW, reason=reason)
+            case "*":
+                return GameOutcome(kind=OutcomeKind.UNKNOWN, reason=reason)
+            case other:
+                raise ValueError(
+                    f"unexpected result value {other} in {self.__class__.__name__}"
+                )
+
+    def _assessment_from_over_event(
+        self, winner: Winner, how_over: HowOver, reason: str | None = None
+    ) -> PositionAssessment:
+        if how_over is HowOver.DRAW:
+            return PositionAssessment(kind=VerdictKind.DRAW, reason=reason)
+        if how_over is HowOver.WIN:
+            mapped_winner: Color | None = None
+            if winner is Winner.WHITE:
+                mapped_winner = Color.WHITE
+            elif winner is Winner.BLACK:
+                mapped_winner = Color.BLACK
+            if mapped_winner is None:
+                return PositionAssessment(kind=VerdictKind.UNKNOWN, reason=reason)
+            return PositionAssessment(
+                kind=VerdictKind.WIN, winner=mapped_winner, reason=reason
+            )
+        return PositionAssessment(kind=VerdictKind.UNKNOWN, reason=reason)
+
+    @staticmethod
+    def _result_string_outcome(outcome: GameOutcome) -> str:
+        if outcome.kind is OutcomeKind.WIN and outcome.winner is Color.WHITE:
+            return "1-0"
+        if outcome.kind is OutcomeKind.WIN and outcome.winner is Color.BLACK:
+            return "0-1"
+        if outcome.kind is OutcomeKind.DRAW:
+            return "1/2-1/2"
+        return "*"
+
+    @staticmethod
+    def _result_string_assessment(assessment: PositionAssessment) -> str:
+        if assessment.kind is VerdictKind.WIN and assessment.winner is Color.WHITE:
+            return "1-0"
+        if assessment.kind is VerdictKind.WIN and assessment.winner is Color.BLACK:
+            return "0-1"
+        if assessment.kind is VerdictKind.DRAW:
+            return "1/2-1/2"
+        return "*"
+
+    @staticmethod
+    def _termination_reason(state: IBoard) -> str | None:
+        termination = state.termination()
+        if termination is None:
+            return None
+        return str(termination)

--- a/chipiron/environments/environment.py
+++ b/chipiron/environments/environment.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+from chipiron.environments.types import GameKind
+from chipiron.games.game.game_rules import GameRules
+from chipiron.players.boardevaluators.table_base.factory import AnySyzygyTable
+from chipiron.players.communications.player_request_encoder import PlayerRequestEncoder
+from chipiron.utils.communication.gui_encoder import GuiEncoder
+from chipiron.scripts.chipiron_args import ImplementationArgs
+
+if TYPE_CHECKING:
+    from chipiron.players.factory_higher_level import PlayerObserverFactory
+
+StateT = TypeVar("StateT")
+StateSnapT = TypeVar("StateSnapT")
+
+class PlayerObserverFactoryBuilder(Protocol):
+    def __call__(
+        self,
+        *,
+        each_player_has_its_own_thread: bool,
+        implementation_args: ImplementationArgs,
+        universal_behavior: bool,
+    ) -> "PlayerObserverFactory": ...
+
+
+@dataclass(frozen=True)
+class Environment(Generic[StateT, StateSnapT]):
+    game_kind: GameKind
+    rules: GameRules[StateT]
+    gui_encoder: GuiEncoder[StateT]
+    player_encoder: PlayerRequestEncoder[StateT, StateSnapT]
+    make_player_observer_factory: PlayerObserverFactoryBuilder
+
+
+def make_environment(
+    *,
+    game_kind: GameKind,
+    syzygy_table: AnySyzygyTable | None,
+) -> Environment[Any, Any]:
+    match game_kind:
+        case GameKind.CHESS:
+            from chipiron.environments.chess.chess_gui_encoder import ChessGuiEncoder
+            from chipiron.environments.chess.chess_rules import ChessRules
+            from chipiron.players.communications.player_request_encoder import (
+                ChessPlayerRequestEncoder,
+            )
+            from chipiron.players.factory_higher_level import (
+                create_player_observer_factory,
+            )
+
+            def build_player_observer_factory(
+                *,
+                each_player_has_its_own_thread: bool,
+                implementation_args: ImplementationArgs,
+                universal_behavior: bool,
+            ) -> "PlayerObserverFactory":
+                return create_player_observer_factory(
+                    game_kind=GameKind.CHESS,
+                    each_player_has_its_own_thread=each_player_has_its_own_thread,
+                    implementation_args=implementation_args,
+                    universal_behavior=universal_behavior,
+                    syzygy_table=syzygy_table,
+                )
+
+            return Environment(
+                game_kind=game_kind,
+                rules=ChessRules(syzygy=syzygy_table),
+                gui_encoder=ChessGuiEncoder(),
+                player_encoder=ChessPlayerRequestEncoder(),
+                make_player_observer_factory=build_player_observer_factory,
+            )
+        case GameKind.CHECKERS:
+            raise NotImplementedError(
+                "Environment for CHECKERS is not implemented yet"
+            )
+        case _:
+            raise ValueError(f"No Environment for game_kind={game_kind!r}")

--- a/chipiron/games/game/game_rules.py
+++ b/chipiron/games/game/game_rules.py
@@ -1,0 +1,86 @@
+"""
+Protocol and data structures for game-specific rules and outcomes.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, TypeVar
+
+from valanga import Color
+
+from .final_game_result import FinalGameResult
+
+StateT = TypeVar("StateT")
+
+
+class OutcomeKind(str, Enum):
+    WIN = "win"
+    DRAW = "draw"
+    ABORTED = "aborted"
+    UNKNOWN = "unknown"
+
+
+class OutcomeSource(str, Enum):
+    TERMINAL = "terminal"
+    ADJUDICATED = "adjudicated"
+
+
+class VerdictKind(str, Enum):
+    WIN = "win"
+    DRAW = "draw"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class GameOutcome:
+    kind: OutcomeKind
+    winner: Color | None = None
+    reason: str | None = None
+    source: OutcomeSource = OutcomeSource.TERMINAL
+
+
+@dataclass(frozen=True)
+class PositionAssessment:
+    kind: VerdictKind
+    winner: Color | None = None
+    reason: str | None = None
+
+
+class GameRules(Protocol[StateT]):
+    def outcome(self, state: StateT) -> GameOutcome | None:
+        """Return None if not terminal; otherwise a GameOutcome."""
+        ...
+
+    def pretty_result(self, state: StateT, outcome: GameOutcome) -> str:
+        """Return a human-friendly string describing the outcome."""
+        ...
+
+    def assessment(self, state: StateT) -> PositionAssessment | None:
+        """Return a non-terminal assessment such as tablebase verdicts."""
+        ...
+
+    def pretty_assessment(
+        self, state: StateT, assessment: PositionAssessment
+    ) -> str:
+        """Return a human-friendly string describing the assessment."""
+        ...
+
+
+def outcome_to_final_game_result(outcome: GameOutcome) -> FinalGameResult:
+    """
+    Map a generic game outcome to the legacy FinalGameResult enum.
+
+    Unknown/aborted outcomes map to draws to preserve legacy behavior when
+    a game stops before a clean adjudication is available.
+    """
+    if outcome.kind is OutcomeKind.WIN:
+        if outcome.winner is Color.WHITE:
+            return FinalGameResult.WIN_FOR_WHITE
+        if outcome.winner is Color.BLACK:
+            return FinalGameResult.WIN_FOR_BLACK
+        raise ValueError("Winner must be provided for WIN outcomes.")
+    if outcome.kind is OutcomeKind.DRAW:
+        return FinalGameResult.DRAW
+    if outcome.kind in (OutcomeKind.ABORTED, OutcomeKind.UNKNOWN):
+        return FinalGameResult.DRAW
+    raise ValueError(f"Unhandled outcome kind: {outcome.kind}")


### PR DESCRIPTION
### Motivation
- Centralize and type the environment bundle so game-specific wiring is lazy, type-safe, and avoids import cycles. 
- Remove redundant `syzygy_table` plumbing and move result/assessment logic into a `GameRules` adapter so `GameManager` no longer handles syzygy/details directly.

### Description
- Introduce a generic `GameRules` protocol and helpers in `chipiron/games/game/game_rules.py` plus a `ChessRules` adapter in `chipiron/environments/chess/chess_rules.py` providing terminal outcomes and tablebase-aware assessments. 
- Add an `Environment` and `make_environment()` in `chipiron/environments/environment.py` that bundles `rules`, `gui_encoder`, `player_encoder`, and a `make_player_observer_factory` builder, and close over `syzygy_table` in the builder. 
- Tighten the `PlayerObserverFactoryBuilder` typing to use `ImplementationArgs` and avoid importing `PlayerObserverFactory` at import time by using `TYPE_CHECKING`. 
- Update `GameManagerFactory` to call `make_environment()` and use `environment.gui_encoder`, `environment.player_encoder`, and `environment.make_player_observer_factory(...)` while removing redundant `syzygy_table` argument; update `GameManager` to accept `rules: GameRules` and use `rules.outcome()`/`rules.assessment()` and `outcome_to_final_game_result()` instead of direct syzygy handling. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e52f18274832b95097d1c0d4be3e6)