### PR TITLE
Relocate StartingPositionArgs to environments and type EnvironmentDeps.board_factory as Any

### DIFF
--- a/chipiron/environments/chess/starting_position_args.py
+++ b/chipiron/environments/chess/starting_position_args.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from importlib import resources
+from pathlib import Path
+from typing import TypeAlias
+
+from chipiron.environments.chess.tags import ChessStartTag
+from chipiron.environments.starting_position import StartingPositionArgs
+from valanga import StateTag
+
+
+class StartingPositionArgsType(str, Enum):
+    FEN = "fen"
+    FROM_FILE = "from_file"
+
+
+@dataclass(frozen=True)
+class FenStartingPositionArgs(StartingPositionArgs):
+    type: StartingPositionArgsType = StartingPositionArgsType.FEN
+    fen: str = ""
+
+    def get_start_tag(self) -> StateTag:
+        if not self.fen:
+            raise ValueError("Empty fen in FenStartingPositionArgs")
+        return ChessStartTag(fen=self.fen)
+
+
+@dataclass(frozen=True)
+class FileStartingPositionArgs(StartingPositionArgs):
+    type: StartingPositionArgsType = StartingPositionArgsType.FROM_FILE
+    file_name: str = ""
+
+    def get_start_tag(self) -> StateTag:
+        if not self.file_name:
+            raise ValueError("Empty file_name in FileStartingPositionArgs")
+        fen = _load_fen_from_file(self.file_name)
+        return ChessStartTag(fen=fen)
+
+
+AllStartingPositionArgs: TypeAlias = (
+    FenStartingPositionArgs | FileStartingPositionArgs
+)
+
+
+def _load_fen_from_file(file_name: str) -> str:
+    path = Path(file_name)
+    if not path.is_file():
+        path = _resolve_starting_board_path(file_name)
+    fen = _load_fen_from_path(path)
+    if not fen:
+        raise ValueError(f"Starting position file is empty: {path}")
+    return fen
+
+
+def _resolve_starting_board_path(file_name: str) -> Path:
+    try:
+        starting_boards = resources.files("chipiron.data").joinpath(
+            "starting_boards"
+        )
+    except ModuleNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Starting position file not found: {file_name}"
+        ) from exc
+    resource_path = starting_boards.joinpath(file_name)
+    if not resource_path.is_file():
+        raise FileNotFoundError(
+            f"Starting position file not found: {file_name}"
+        )
+    with resources.as_file(resource_path) as resolved:
+        return resolved
+
+
+def _load_fen_from_path(path: Path) -> str:
+    contents = path.read_text(encoding="utf-8").strip()
+    if not contents:
+        return ""
+    if _looks_like_fen(contents):
+        return contents
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    if len(lines) < 9:
+        raise ValueError(f"Invalid starting position file: {path}")
+    board_lines = lines[:8]
+    suffix = " ".join(lines[8:])
+    board_fen = "/".join(_compress_rank(line) for line in board_lines)
+    return f"{board_fen} {suffix}".strip()
+
+
+def _looks_like_fen(contents: str) -> bool:
+    parts = contents.split()
+    if len(parts) < 6:
+        return False
+    board = parts[0]
+    return board.count("/") == 7
+
+
+def _compress_rank(rank: str) -> str:
+    if len(rank) != 8:
+        raise ValueError(f"Invalid board rank: {rank!r}")
+    result: list[str] = []
+    empty_count = 0
+    for char in rank:
+        if char in {"1", ".", "0", "-"}:
+            empty_count += 1
+        else:
+            if empty_count:
+                result.append(str(empty_count))
+                empty_count = 0
+            result.append(char)
+    if empty_count:
+        result.append(str(empty_count))
+    return "".join(result)

--- a/chipiron/environments/chess/tags.py
+++ b/chipiron/environments/chess/tags.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ChessStartTag:
+    fen: str

--- a/chipiron/environments/starting_position.py
+++ b/chipiron/environments/starting_position.py
@@ -1,0 +1,7 @@
+from typing import Protocol
+
+from valanga import StateTag
+
+
+class StartingPositionArgs(Protocol):
+    def get_start_tag(self) -> StateTag: ...

--- a/chipiron/games/game/game_args.py
+++ b/chipiron/games/game/game_args.py
@@ -4,9 +4,7 @@ Module that contains the GameArgs class.
 
 from dataclasses import dataclass
 
-from atomheart.board.starting_position import (
-    AllStartingPositionArgs,
-)
+from chipiron.environments.starting_position import StartingPositionArgs
 
 from chipiron.environments.types import GameKind
 
@@ -17,12 +15,12 @@ class GameArgs:
     Represents the arguments for a game.
 
     Attributes:
-        starting_position (AllStartingPositionArgs): The starting position of the game.
+        starting_position (StartingPositionArgs): The starting position of the game.
         max_half_moves (int | None, optional): The maximum number of half moves allowed in the game. Defaults to None.
         each_player_has_its_own_thread (bool, optional): Whether each player has its own thread. Defaults to False.
     """
 
     game_kind: GameKind
-    starting_position: AllStartingPositionArgs
+    starting_position: StartingPositionArgs
     max_half_moves: int | None = None
     each_player_has_its_own_thread: bool = False

--- a/chipiron/games/game/game_manager_factory.py
+++ b/chipiron/games/game/game_manager_factory.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import atomheart.board as boards
-from atomheart.board.utils import FenPlusHistory
 from atomheart.move_factory import MoveFactory
 from valanga import Color
 from valanga.game import Seed
@@ -28,7 +27,7 @@ from chipiron.players.boardevaluators.board_evaluator import (
     IGameStateEvaluator,
     ObservableBoardEvaluator,
 )
-from chipiron.environments.environment import make_environment
+from chipiron.environments.environment import EnvironmentDeps, make_environment
 from chipiron.players.factory_higher_level import MoveFunction, PlayerObserverFactory
 from chipiron.utils import path
 from chipiron.utils.communication.gui_messages.gui_messages import (
@@ -133,11 +132,15 @@ class GameManagerFactory:
         else:
             display_state_evaluator = self.game_manager_board_evaluator
 
-        # CREATING THE BOARD
-        starting_fen: str = args_game_manager.starting_position.get_fen()
-        board: boards.IBoard = self.board_factory(
-            fen_with_history=FenPlusHistory(current_fen=starting_fen)
+        environment = make_environment(
+            game_kind=args_game_manager.game_kind,
+            syzygy_table=self.syzygy_table,
+            deps=EnvironmentDeps(board_factory=self.board_factory),
         )
+
+        start_tag = args_game_manager.starting_position.get_start_tag()
+        normalized_start_tag = environment.normalize_start_tag(start_tag)
+        board = environment.make_initial_state(normalized_start_tag)
         for publisher in publishers:
             payload = make_players_info_payload(
                 player_color_to_factory_args=player_color_to_factory_args
@@ -152,10 +155,6 @@ class GameManagerFactory:
 
         game: Game = Game(
             playing_status=game_playing_status, state=board, seed_=game_seed
-        )
-
-        environment = make_environment(
-            game_kind=args_game_manager.game_kind, syzygy_table=self.syzygy_table
         )
 
         observable_game: ObservableGame = ObservableGame(

--- a/chipiron/scripts/script_gui/script_gui_custom.py
+++ b/chipiron/scripts/script_gui/script_gui_custom.py
@@ -19,7 +19,7 @@ from anemone.progress_monitor.progress_monitor import (
     StoppingCriterionTypes,
     TreeBranchLimitArgs,
 )
-from atomheart.board.starting_position import (
+from chipiron.environments.chess.starting_position_args import (
     FenStartingPositionArgs,
     StartingPositionArgsType,
 )


### PR DESCRIPTION
### Motivation
- Keep layering clean by making starting-position arguments an environment concern rather than part of the game loop, so the protocol does not leak into `games.game`.
- Clarify that `EnvironmentDeps.board_factory` is an untyped dependency bag by using `Any`, avoiding frequent `cast(...)` footguns and better expressing intent.

### Description
- Move the `StartingPositionArgs` protocol from `chipiron/games/game/starting_position.py` into `chipiron/environments/starting_position.py` and remove the old file.
- Update imports and type annotations so `GameArgs.starting_position` uses the protocol from `chipiron.environments.starting_position` and chess starting-position implementations import the protocol from the environments package.
- Change `EnvironmentDeps.board_factory` to `Any | None` in `chipiron/environments/environment.py` and keep the chess environment casting/check and runtime validation in `make_environment`.
- Update callers to use the environment dependency bag (import `EnvironmentDeps`, pass `deps=EnvironmentDeps(board_factory=...)`) and adjust the GUI script import to use `chipiron.environments.chess.starting_position_args`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2b620b10832b8c5bdef50d56df21)