### PR TITLE
Tighten oracle wiring typing and stockfish checks

### DIFF
--- a/chipiron/displays/gui_protocol.py
+++ b/chipiron/displays/gui_protocol.py
@@ -56,6 +56,11 @@ class UpdPlayerProgress:
 
 @dataclass(frozen=True, slots=True)
 class UpdEvaluation:
+    """Evaluation update payload.
+
+    Note: ``stock`` carries the external oracle evaluation (Stockfish for chess).
+    """
+
     stock: float | None
     chipiron: float | None
     white: float | None = None

--- a/chipiron/environments/chess/types.py
+++ b/chipiron/environments/chess/types.py
@@ -1,0 +1,7 @@
+"""
+Shared chess type aliases.
+"""
+
+from atomheart.board.valanga_adapter import ValangaChessState
+
+ChessState = ValangaChessState

--- a/chipiron/games/match/match_factories.py
+++ b/chipiron/games/match/match_factories.py
@@ -4,7 +4,7 @@ This module contains functions for creating match managers in the Chipiron game 
 
 import multiprocessing
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from atomheart.board.factory import (
     BoardFactory,
@@ -21,7 +21,9 @@ from chipiron.games.game.game_manager_factory import GameManagerFactory
 from chipiron.games.match.match_args import MatchArgs
 from chipiron.games.match.match_manager import MatchManager
 from chipiron.games.match.match_results_factory import MatchResultsFactory
-from chipiron.players.boardevaluators.factory import create_game_board_evaluator
+from chipiron.players.boardevaluators.factory import (
+    create_game_board_evaluator_for_game_kind,
+)
 from chipiron.players.boardevaluators.table_base.factory import (
     AnySyzygyTable,
     create_syzygy,
@@ -79,11 +81,16 @@ def create_match_manager(
     player_one_name: str = args_player_one.name
     player_two_name: str = args_player_two.name
 
-    can_stockfish: bool = args_player_one.name not in [
+    can_oracle: bool = args_player_one.name not in [
         "Stockfish"
     ] and args_player_two.name not in ["Stockfish"]
-    game_board_evaluator: IGameStateEvaluator[StateT] = create_game_board_evaluator(
-        gui=gui, can_stockfish=can_stockfish
+    game_board_evaluator = cast(
+        "IGameStateEvaluator[StateT]",
+        create_game_board_evaluator_for_game_kind(
+            game_kind=args_game.game_kind,
+            gui=gui,
+            can_oracle=can_oracle,
+        ),
     )
 
     board_factory: BoardFactory = create_board_factory(

--- a/chipiron/players/boardevaluators/basic_evaluation.py
+++ b/chipiron/players/boardevaluators/basic_evaluation.py
@@ -8,7 +8,6 @@ import chess
 from atomheart.board import IBoard
 from chess import Square
 
-from chipiron.players.boardevaluators.board_evaluator import StateEvaluator
 
 
 def value_base(board: IBoard, color: chess.Color) -> int:
@@ -121,7 +120,7 @@ def value_player_to_move(board: IBoard) -> float:
     return value
 
 
-class BasicEvaluation(StateEvaluator):
+class BasicEvaluation:
     """A basic board evaluator that calculates the value of the board for the white player.
 
     Args:
@@ -135,20 +134,20 @@ class BasicEvaluation(StateEvaluator):
 
     """
 
-    def value_white(self, board: IBoard) -> float:
+    def value_white(self, state: IBoard) -> float:
         """Calculates the value of the board for the white player.
 
         Args:
-            board (BoardChi): The chess board.
+            state (BoardChi): The chess board.
 
         Returns:
             float: The value of the board for the white player.
 
         """
-        value_white_pieces: float = float(value_base(board, chess.WHITE))
-        value_black_pieces: float = float(value_base(board, chess.BLACK))
-        value_white_pieces += add_pawns_value_white(board)
-        value_black_pieces += add_pawns_value_black(board)
+        value_white_pieces: float = float(value_base(state, chess.WHITE))
+        value_black_pieces: float = float(value_base(state, chess.BLACK))
+        value_white_pieces += add_pawns_value_white(state)
+        value_black_pieces += add_pawns_value_black(state)
 
         return (
             value_white_pieces - value_black_pieces

--- a/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -71,16 +71,16 @@ class MasterBoardEvaluator:
         self.syzygy_evaluator = syzygy
         self.value_over_enum = value_over_enum
 
-    def value_white(self, board: IBoard) -> float:
+    def value_white(self, state: IBoard) -> float:
         """
         Calculates the value for the white player of a given node.
         If the value can be obtained from the syzygy evaluator, it is used.
         Otherwise, the board evaluator is used.
         """
-        value_white: float | None = self.syzygy_value_white(board)
+        value_white: float | None = self.syzygy_value_white(state)
         value_white_float: float
         if value_white is None:
-            value_white_float = self.board_evaluator.value_white(board)
+            value_white_float = self.board_evaluator.value_white(state)
         else:
             value_white_float = value_white
         return value_white_float

--- a/chipiron/players/boardevaluators/stockfish_board_evaluator.py
+++ b/chipiron/players/boardevaluators/stockfish_board_evaluator.py
@@ -3,6 +3,7 @@ Module where we define the Stockfish Board Evaluator
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import atomheart.board as boards
@@ -11,6 +12,7 @@ from atomheart.board.factory import create_board_chi
 from atomheart.board.utils import FenPlusHistory
 
 from chipiron.players.boardevaluators.board_evaluator_type import BoardEvalTypes
+from chipiron.utils.path_variables import STOCKFISH_BINARY_PATH
 from chipiron.utils.logger import chipiron_logger
 
 if TYPE_CHECKING:
@@ -64,6 +66,19 @@ class StockfishBoardEvaluator:
         self.args = args
         self.engine = None
 
+    @staticmethod
+    def _candidate_paths() -> list[str]:
+        return [
+            str(STOCKFISH_BINARY_PATH),
+            "/usr/games/stockfish",
+            "stockfish",
+            r"stockfish/stockfish/stockfish-ubuntu-x86-64-avx2",
+        ]
+
+    @staticmethod
+    def is_available() -> bool:
+        return any(Path(path).exists() for path in StockfishBoardEvaluator._candidate_paths())
+
     def value_white(self, state: boards.IBoard) -> float:
         """
         Computes the value of the board for the white player.
@@ -77,13 +92,7 @@ class StockfishBoardEvaluator:
         try:
             if self.engine is None:
                 # Try multiple possible Stockfish paths
-                stockfish_paths = [
-                    "/usr/games/stockfish",
-                    "stockfish",
-                    r"stockfish/stockfish/stockfish-ubuntu-x86-64-avx2",
-                ]
-
-                for path in stockfish_paths:
+                for path in self._candidate_paths():
                     try:
                         self.engine = chess.engine.SimpleEngine.popen_uci(path)
                         break

--- a/chipiron/players/boardevaluators/table_base/syzygy_table.py
+++ b/chipiron/players/boardevaluators/table_base/syzygy_table.py
@@ -131,19 +131,19 @@ class SyzygyTable[T_Board: IBoard](Protocol):
         val: int = self.wdl(board)
         return val
 
-    def value_white(self, board: T_Board) -> int:
+    def value_white(self, state: T_Board) -> int:
         """
         Get the value of the given board for the white player.
 
         Args:
-            board (boards.BoardChi): The board to get the value for.
+            state (boards.BoardChi): The board to get the value for.
 
         Returns:
             int: The value of the board for the white player.
         """
         # tablebase.probe_wdl Returns 2 if the side to move is winning, 0 if the position is a draw and -2 if the side to move is losing.
-        val: int = self.wdl(board)
-        if board.turn == chess.WHITE:
+        val: int = self.wdl(state)
+        if state.turn == chess.WHITE:
             return val * 100000
         else:
             return val * -10000

--- a/chipiron/players/boardevaluators/wirings/__init__.py
+++ b/chipiron/players/boardevaluators/wirings/__init__.py
@@ -1,0 +1,3 @@
+"""
+Game-specific wiring for board evaluators.
+"""

--- a/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
+++ b/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
@@ -1,0 +1,96 @@
+"""
+Chess-specific wiring for board evaluators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.resources import files
+
+from atomheart.board import IBoard
+from chipiron.environments.chess.types import ChessState
+import parsley_coco
+
+from coral.neural_networks.neural_net_board_eval_args import NeuralNetBoardEvalArgs
+from chipiron.players.boardevaluators.all_board_evaluator_args import (
+    AllBoardEvaluatorArgs,
+    BasicEvaluationBoardEvaluatorArgs,
+)
+from chipiron.players.boardevaluators.basic_evaluation import BasicEvaluation
+from chipiron.players.boardevaluators.board_evaluator import StateEvaluator
+from chipiron.players.boardevaluators.neural_networks.factory import (
+    create_nn_board_eval_from_nn_parameters_file_and_existing_model,
+)
+from chipiron.players.boardevaluators.stockfish_board_evaluator import (
+    StockfishBoardEvalArgs,
+    StockfishBoardEvaluator,
+)
+from chipiron.utils.logger import chipiron_logger
+
+
+@dataclass(frozen=True, slots=True)
+class BoardEvalArgsWrapper:
+    board_evaluator: AllBoardEvaluatorArgs
+
+
+def _load_chipiron_eval_args() -> AllBoardEvaluatorArgs:
+    path = str(
+        files("chipiron").joinpath(
+            "data/players/board_evaluator_config/base_chipiron_board_eval.yaml"
+        )
+    )
+    wrapper: BoardEvalArgsWrapper = parsley_coco.resolve_yaml_file_to_base_dataclass(
+        yaml_path=path,
+        base_cls=BoardEvalArgsWrapper,
+        package_name=str(files("chipiron")),
+    )
+    return wrapper.board_evaluator
+
+
+class ValangaBoardEvaluator(StateEvaluator[ChessState]):
+    def __init__(self, evaluator: StateEvaluator[IBoard]) -> None:
+        self._evaluator = evaluator
+
+    def value_white(self, state: ChessState) -> float:
+        return self._evaluator.value_white(state.board)
+
+
+def _build_chi() -> StateEvaluator[ChessState]:
+    args = _load_chipiron_eval_args()
+    match args:
+        case BasicEvaluationBoardEvaluatorArgs():
+            return ValangaBoardEvaluator(BasicEvaluation())
+        case NeuralNetBoardEvalArgs():
+            nn = args.neural_nets_model_and_architecture
+            return ValangaBoardEvaluator(
+                create_nn_board_eval_from_nn_parameters_file_and_existing_model(
+                    model_weights_file_name=nn.model_weights_file_name,
+                    nn_architecture_args=nn.nn_architecture_args,
+                )
+            )
+        case _:
+            raise ValueError(f"Unsupported chi args: {args!r}")
+
+
+def _build_oracle(*, can_oracle: bool) -> StateEvaluator[ChessState] | None:
+    if not can_oracle:
+        return None
+    if not StockfishBoardEvaluator.is_available():
+        chipiron_logger.warning(
+            "Stockfish binary not available; disabling oracle evaluator."
+        )
+        return None
+    return ValangaBoardEvaluator(
+        StockfishBoardEvaluator(StockfishBoardEvalArgs(depth=20, time_limit=0.1))
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ChessEvalWiring:
+    can_oracle: bool
+
+    def build_chi(self) -> StateEvaluator[ChessState]:
+        return _build_chi()
+
+    def build_oracle(self) -> StateEvaluator[ChessState] | None:
+        return _build_oracle(can_oracle=self.can_oracle)

--- a/chipiron/players/boardevaluators/wirings/null_eval_wiring.py
+++ b/chipiron/players/boardevaluators/wirings/null_eval_wiring.py
@@ -1,0 +1,27 @@
+"""
+Fallback evaluator wiring for games without a specific evaluator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chipiron.players.boardevaluators.board_evaluator import StateEvaluator
+
+
+class ConstantEvaluator:
+    def __init__(self, value: float = 0.0) -> None:
+        self._value = value
+
+    def value_white(self, state: object) -> float:
+        _ = state
+        return self._value
+
+
+@dataclass(frozen=True, slots=True)
+class NullEvalWiring:
+    def build_chi(self) -> StateEvaluator[object]:
+        return ConstantEvaluator()
+
+    def build_oracle(self) -> StateEvaluator[object] | None:
+        return None

--- a/chipiron/players/boardevaluators/wirings/protocols.py
+++ b/chipiron/players/boardevaluators/wirings/protocols.py
@@ -1,0 +1,17 @@
+"""
+Protocols for wiring game-specific evaluators.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from chipiron.players.boardevaluators.board_evaluator import StateEvaluator
+
+StateT = TypeVar("StateT")
+
+
+class EvaluatorWiring(Protocol[StateT]):
+    def build_chi(self) -> StateEvaluator[StateT]: ...
+
+    def build_oracle(self) -> StateEvaluator[StateT] | None: ...

--- a/tests/boardevaluators/test_oracle_wiring.py
+++ b/tests/boardevaluators/test_oracle_wiring.py
@@ -1,0 +1,68 @@
+import queue
+
+import chess
+import pytest
+from atomheart.board import IBoard, create_board
+from atomheart.board.utils import FenPlusHistory
+
+from chipiron.displays.gui_protocol import GuiUpdate, UpdEvaluation, make_scope
+from chipiron.displays.gui_publisher import GuiPublisher
+from chipiron.environments.chess.types import ChessState
+from chipiron.environments.types import GameKind
+from chipiron.players.boardevaluators.board_evaluator import (
+    ObservableGameStateEvaluator,
+)
+from chipiron.players.boardevaluators.factory import (
+    create_game_board_evaluator_for_game_kind,
+)
+
+
+@pytest.mark.parametrize(("use_rust_boards"), (True, False))
+def test_chess_evaluator_accepts_chess_state(use_rust_boards: bool) -> None:
+    board: IBoard = create_board(
+        use_rust_boards=use_rust_boards,
+        fen_with_history=FenPlusHistory(current_fen=chess.STARTING_FEN),
+    )
+    state = ChessState(board=board)
+
+    evaluator = create_game_board_evaluator_for_game_kind(
+        game_kind=GameKind.CHESS,
+        gui=False,
+        can_oracle=False,
+    )
+
+    oracle, chi = evaluator.evaluate(state)
+
+    assert oracle is None
+    assert isinstance(chi, float)
+
+
+def test_gui_evaluator_publishes_oracle_field() -> None:
+    board: IBoard = create_board(
+        use_rust_boards=False,
+        fen_with_history=FenPlusHistory(current_fen=chess.STARTING_FEN),
+    )
+    state = ChessState(board=board)
+
+    evaluator = create_game_board_evaluator_for_game_kind(
+        game_kind=GameKind.CHESS,
+        gui=True,
+        can_oracle=False,
+    )
+    assert isinstance(evaluator, ObservableGameStateEvaluator)
+
+    out: queue.Queue[GuiUpdate] = queue.Queue()
+    scope = make_scope(session_id="session", match_id="match", game_id="game")
+    publisher = GuiPublisher(
+        out=out,
+        schema_version=1,
+        game_kind=GameKind.CHESS,
+        scope=scope,
+    )
+
+    evaluator.subscribe(publisher)
+    _ = evaluator.evaluate(state)
+
+    update = out.get_nowait()
+    assert isinstance(update.payload, UpdEvaluation)
+    assert update.payload.stock is None


### PR DESCRIPTION
### Motivation
- Ensure the oracle (Stockfish) availability check matches the evaluator's search paths and expose a shared helper so wiring decisions are reliable at runtime.
- Make the chess wiring and factory boundaries more type-friendly so callers get better type errors and fewer casts when working with chess-specific state.
- Harden test typing for the GUI publishing path to keep static checkers happy and prevent payload drift.

### Description
- Added `_candidate_paths()` and `is_available()` helpers to `StockfishBoardEvaluator` and consolidated Stockfish lookup to use `pathlib.Path` checks; the evaluator now tries the same candidate paths when launching the engine (`chipiron/players/boardevaluators/stockfish_board_evaluator.py`).
- Annotated the chess adapter as implementing the evaluator protocol by making `ValangaBoardEvaluator` inherit `StateEvaluator[ChessState]` and updated the chess wiring to gate the oracle with `StockfishBoardEvaluator.is_available()` (`chipiron/players/boardevaluators/wirings/chess_eval_wiring.py`).
- Added overloads for `_select_eval_wiring` and `create_game_board_evaluator_for_game_kind` to improve typing at the game-kind boundary and kept a single cast at the runtime entrypoint (`chipiron/players/boardevaluators/factory.py`).
- Tightened test typing in the GUI wiring test by typing the output queue as `queue.Queue[GuiUpdate]` and importing `GuiUpdate` (`tests/boardevaluators/test_oracle_wiring.py`).

### Testing
- No automated tests were executed locally for these changes and no test run results are included here; CI should run the test suite to validate runtime behavior and typing.
- The unit test file `tests/boardevaluators/test_oracle_wiring.py` was updated to reflect the stricter typing and should be exercised by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a1718684832b94458113d1654bc2)