### PR TITLE
Add version guard for Chipiron NN args and wire content-to-input from saved metadata

### DIFF
--- a/chipiron/data/players/board_evaluators/nn_pytorch/prelu_no_bug/chipiron_nn.yaml
+++ b/chipiron/data/players/board_evaluators/nn_pytorch/prelu_no_bug/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: 364_no_bug

--- a/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -20,6 +20,9 @@ from chipiron.players.boardevaluators.board_evaluator_type import (
     BoardEvalTypes,
     to_board_eval_type,
 )
+from chipiron.players.boardevaluators.neural_networks.chipiron_nn_args import (
+    create_content_to_input_from_model_weights,
+)
 from chipiron.players.boardevaluators.evaluation_scale import (
     EvaluationScale,
     ValueOverEnum,
@@ -238,6 +241,9 @@ def create_master_board_evaluator_from_args(
             board_evaluator = create_nn_content_eval_from_nn_parameters_file_and_existing_model(
                 model_weights_file_name=master_board_evaluator.board_evaluator.neural_nets_model_and_architecture.model_weights_file_name,
                 nn_architecture_args=master_board_evaluator.board_evaluator.neural_nets_model_and_architecture.nn_architecture_args,
+                content_to_input_convert=create_content_to_input_from_model_weights(
+                    master_board_evaluator.board_evaluator.neural_nets_model_and_architecture.model_weights_file_name
+                ),
             )
         case other:
             raise ValueError(

--- a/chipiron/players/boardevaluators/neural_networks/chipiron_nn_args.py
+++ b/chipiron/players/boardevaluators/neural_networks/chipiron_nn_args.py
@@ -1,0 +1,127 @@
+"""Chipiron-specific neural network wiring arguments."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable
+
+import yaml
+from coral.neural_networks.input_converters.content_to_input import (
+    ContentToInputFunction,
+)
+
+from chipiron.environments.types import GameKind
+from chipiron.players.boardevaluators.neural_networks.input_converters.ModelInputRepresentationType import (
+    ModelInputRepresentationType,
+)
+from chipiron.players.boardevaluators.neural_networks.input_converters.board_to_input import (
+    create_board_to_input,
+)
+from chipiron.utils import path
+
+
+CHIPIRON_NN_ARGS_FILENAME = "chipiron_nn.yaml"
+
+
+@dataclass(frozen=True, slots=True)
+class ChipironNNArgs:
+    version: int
+    game_kind: GameKind
+    input_representation: str
+
+
+ContentToInputBuilder = Callable[[str], ContentToInputFunction]
+
+
+def get_chipiron_nn_args_file_path_from(folder_path: path) -> str:
+    return os.path.join(folder_path, CHIPIRON_NN_ARGS_FILENAME)
+
+
+def _serialize_chipiron_nn_args(args: ChipironNNArgs) -> dict[str, int | str]:
+    return {
+        "version": args.version,
+        "game_kind": args.game_kind.value,
+        "input_representation": args.input_representation,
+    }
+
+
+def save_chipiron_nn_args(args: ChipironNNArgs, folder_path: path) -> None:
+    file_path = get_chipiron_nn_args_file_path_from(folder_path)
+    with open(file_path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(_serialize_chipiron_nn_args(args), handle)
+
+
+def load_chipiron_nn_args(folder_path: path) -> ChipironNNArgs:
+    file_path = get_chipiron_nn_args_file_path_from(folder_path)
+    with open(file_path, "r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid chipiron NN args in {file_path!r}.")
+    try:
+        version_raw = payload.get("version", 1)
+        version = int(version_raw)
+        game_kind = GameKind(str(payload["game_kind"]))
+        input_representation = str(payload["input_representation"])
+    except KeyError as exc:
+        raise ValueError(
+            f"Missing {exc.args[0]!r} in chipiron NN args at {file_path!r}."
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid chipiron NN args values in {file_path!r}."
+        ) from exc
+    return ChipironNNArgs(
+        version=version,
+        game_kind=game_kind,
+        input_representation=input_representation,
+    )
+
+
+def _create_chess_content_to_input(
+    input_representation: str,
+) -> ContentToInputFunction:
+    representation = ModelInputRepresentationType(input_representation)
+    return create_board_to_input(representation)
+
+
+def _create_checkers_content_to_input(
+    input_representation: str,
+) -> ContentToInputFunction:
+    raise ValueError(
+        f"Checkers input conversion is not implemented: {input_representation}."
+    )
+
+
+_CONTENT_TO_INPUT_BUILDERS: dict[GameKind, ContentToInputBuilder] = {
+    GameKind.CHESS: _create_chess_content_to_input,
+    GameKind.CHECKERS: _create_checkers_content_to_input,
+}
+
+
+def create_content_to_input_convert(
+    chipiron_nn_args: ChipironNNArgs,
+) -> ContentToInputFunction:
+    if chipiron_nn_args.version != 1:
+        raise ValueError(
+            f"Unsupported chipiron NN args version: {chipiron_nn_args.version}."
+        )
+    try:
+        builder = _CONTENT_TO_INPUT_BUILDERS[chipiron_nn_args.game_kind]
+    except KeyError as exc:
+        raise ValueError(
+            f"No content-to-input builder for {chipiron_nn_args.game_kind!r}."
+        ) from exc
+    return builder(chipiron_nn_args.input_representation)
+
+
+def create_content_to_input_from_folder(folder_path: path) -> ContentToInputFunction:
+    chipiron_nn_args = load_chipiron_nn_args(folder_path)
+    return create_content_to_input_convert(chipiron_nn_args)
+
+
+def create_content_to_input_from_model_weights(
+    model_weights_file_name: path,
+) -> ContentToInputFunction:
+    folder_path = os.path.dirname(model_weights_file_name)
+    return create_content_to_input_from_folder(folder_path)

--- a/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
+++ b/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
@@ -21,6 +21,9 @@ from chipiron.players.boardevaluators.board_evaluator import StateEvaluator
 from chipiron.players.boardevaluators.neural_networks.factory import (
     create_nn_board_eval_from_nn_parameters_file_and_existing_model,
 )
+from chipiron.players.boardevaluators.neural_networks.chipiron_nn_args import (
+    create_content_to_input_from_model_weights,
+)
 from chipiron.players.boardevaluators.stockfish_board_evaluator import (
     StockfishBoardEvalArgs,
     StockfishBoardEvaluator,
@@ -66,6 +69,9 @@ def _build_chi() -> StateEvaluator[ChessState]:
                 create_nn_board_eval_from_nn_parameters_file_and_existing_model(
                     model_weights_file_name=nn.model_weights_file_name,
                     nn_architecture_args=nn.nn_architecture_args,
+                    content_to_input_convert=create_content_to_input_from_model_weights(
+                        nn.model_weights_file_name
+                    ),
                 )
             )
         case _:

--- a/chipiron/scripts/evaluate_models/evaluate_models.py
+++ b/chipiron/scripts/evaluate_models/evaluate_models.py
@@ -28,6 +28,10 @@ from chipiron.players.boardevaluators.datasets.datasets import (
     custom_collate_fn_fen_and_value,
     process_stockfish_value,  # pyright: ignore[reportUnknownVariableType]
 )
+from chipiron.players.boardevaluators.neural_networks.chipiron_nn_args import (
+    create_content_to_input_from_model_weights,
+    load_chipiron_nn_args,
+)
 from chipiron.utils import path
 
 if TYPE_CHECKING:
@@ -57,9 +61,15 @@ def compute_model_hash_key(model_and_archi: NeuralNetModelsAndArchitecture) -> s
     Returns:
         str: The computed hash key.
     """
+    chipiron_nn_args = load_chipiron_nn_args(
+        folder_path=os.path.dirname(model_and_archi.model_weights_file_name)
+    )
     return (
         str(model_and_archi.model_weights_file_name)
         + model_and_archi.nn_architecture_args.filename()
+        + str(chipiron_nn_args.version)
+        + chipiron_nn_args.game_kind.value
+        + chipiron_nn_args.input_representation
     )
 
 
@@ -158,6 +168,9 @@ def evaluate_models(
                 create_nn_board_eval_from_nn_parameters_file_and_existing_model(
                     model_weights_file_name=model_to_evaluate.model_weights_file_name,
                     nn_architecture_args=model_to_evaluate.nn_architecture_args,
+                    content_to_input_convert=create_content_to_input_from_model_weights(
+                        model_to_evaluate.model_weights_file_name
+                    ),
                 )
             )
 

--- a/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/learn_from_scratch_value_and_fixed_boards.py
+++ b/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/learn_from_scratch_value_and_fixed_boards.py
@@ -35,6 +35,11 @@ from chipiron.players.boardevaluators.datasets.datasets import (
     DataSetArgs,
     FenAndValueDataSet,
 )
+from chipiron.players.boardevaluators.neural_networks.chipiron_nn_args import (
+    ChipironNNArgs,
+    create_content_to_input_convert,
+    create_content_to_input_from_model_weights,
+)
 from chipiron.players.boardevaluators.table_base.factory import (
     AnySyzygyTable,
     create_syzygy,
@@ -144,13 +149,24 @@ class LearnNNFromScratchScript:
                 self.args.nn_trainer_args.nn_parameters_file_if_reusing_existing_one
                 is not None
             )
+            content_to_input_convert = create_content_to_input_from_model_weights(
+                self.args.nn_trainer_args.nn_parameters_file_if_reusing_existing_one
+            )
             self.nn_board_evaluator = create_nn_content_eval_from_nn_parameters_file_and_existing_model(
                 model_weights_file_name=self.args.nn_trainer_args.nn_parameters_file_if_reusing_existing_one,
                 nn_architecture_args=self.args.nn_trainer_args.neural_network_architecture_args,
+                content_to_input_convert=content_to_input_convert,
             )
         else:
+            chipiron_nn_args = ChipironNNArgs(
+                version=1,
+                game_kind=self.args.nn_trainer_args.game_input.game_kind,
+                input_representation=self.args.nn_trainer_args.game_input.representation.value,
+            )
+            content_to_input_convert = create_content_to_input_convert(chipiron_nn_args)
             self.nn_board_evaluator = create_nn_content_eval_from_architecture_args(
-                nn_architecture_args=self.args.nn_trainer_args.neural_network_architecture_args
+                nn_architecture_args=self.args.nn_trainer_args.neural_network_architecture_args,
+                content_to_input_convert=content_to_input_convert,
             )
 
         if self.args.nn_trainer_args.specific_saving_folder is not None:

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_p1_new/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_p1_new/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: pieces_difference

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_p2/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_p2/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: board_pieces_two_sides

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_pp2_new/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_pp2_new/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: 364_no_bug

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_pp2d3_prelu_new/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/nn_pp2d3_prelu_new/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: 364_no_bug

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/prelu_no_bug/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/prelu_no_bug/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: 364_no_bug

--- a/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/transformerone/chipiron_nn.yaml
+++ b/chipiron/scripts/learn_nn_supervised/board_evaluators_common_training_data/nn_pytorch/transformerone/chipiron_nn.yaml
@@ -1,0 +1,3 @@
+version: 1
+game_kind: chess
+input_representation: piece_map


### PR DESCRIPTION
### Motivation
- Prevent silent misreads of checkpoint metadata by providing a simple version gate for future migrations.
- Make content-to-input builders' naming consistent and centralize per-game wiring via the registry for maintainability.
- Ensure model checkpoints are self-describing and that evaluators/training code reconstruct the `ContentToInputFunction` from saved metadata so saved weights remain usable across processes.

### Description
- Add `ChipironNNArgs` dataclass plus `save_chipiron_nn_args`, `load_chipiron_nn_args`, `create_content_to_input_from_folder`, and `create_content_to_input_from_model_weights` in `chipiron/players/boardevaluators/neural_networks/chipiron_nn_args.py` and include the `chipiron_nn.yaml` filename constant. 
- Enforce a version guard in `create_content_to_input_convert` by raising `ValueError` if `chipiron_nn_args.version != 1`, and make chess/checkers builder functions consistently private (`_create_chess_content_to_input`, `_create_checkers_content_to_input`) with the registry `_CONTENT_TO_INPUT_BUILDERS` updated accordingly.
- Wire reconstruction of the content-to-input converter when loading models by passing `content_to_input_convert=create_content_to_input_from_model_weights(...)` into evaluator factories in `master_board_evaluator.py`, `players/boardevaluators/wirings/chess_eval_wiring.py`, and `scripts/evaluate_models/evaluate_models.py`.
- Use `ChipironNNArgs` when creating evaluators during training runs and persist metadata on saves by calling `save_chipiron_nn_args(...)` in `scripts/learn_nn_supervised/learn_nn_from_supervised_datasets.py` and include usage in `scripts/learn_from_scratch_value_and_fixed_boards/learn_from_scratch_value_and_fixed_boards.py` and `scripts/learn_nn_supervised/learn_nn_from_supervised_datasets.py`.
- Incorporate `chipiron_nn` metadata into model identity by updating `compute_model_hash_key` to include `version`, `game_kind`, and `input_representation`, and add example `chipiron_nn.yaml` files to several `nn_pytorch` model folders.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e37136dc832ba0e8db2ab79db551)