### PR TITLE
Simplify RepresentationBTI generics, add postprocess hook, and fix state->input wrapper

### DIFF
--- a/chipiron/players/boardevaluators/neural_networks/input_converters/representation_factory_factory.py
+++ b/chipiron/players/boardevaluators/neural_networks/input_converters/representation_factory_factory.py
@@ -23,7 +23,7 @@ from .rep_364_bug import (
 
 def create_board_representation_factory(
     internal_tensor_representation_type: InternalTensorRepresentationType,
-) -> RepresentationFactory[ChessState, BoardModificationP, Representation364] | None:
+) -> RepresentationFactory[ChessState, Representation364, BoardModificationP] | None:
     """
     Create a board representation based on the given string.
 
@@ -31,26 +31,26 @@ def create_board_representation_factory(
         internal_tensor_representation_type (InternalTensorRepresentationType): The string representing the board representation.
 
     Returns:
-        RepresentationFactory[ChessState, BoardModificationP, Representation364] | None: The created board representation object, or None if the string is 'no'.
+        RepresentationFactory[ChessState, Representation364, BoardModificationP] | None: The created board representation object, or None if the string is 'no'.
 
     Raises:
         Exception: If the string is not '364'.
 
     """
     board_representation_factory: (
-        RepresentationFactory[ChessState, BoardModificationP, Representation364] | None
+        RepresentationFactory[ChessState, Representation364, BoardModificationP] | None
     )
     match internal_tensor_representation_type:
         case InternalTensorRepresentationType.BUG364:
             board_representation_factory = RepresentationFactory[
-                ChessState, BoardModificationP, Representation364
+                ChessState, Representation364, BoardModificationP
             ](
                 create_from_state=create_from_board_364_bug,
                 create_from_state_and_modifications=create_from_state_and_modifications_364_bug,
             )
         case InternalTensorRepresentationType.NOBUG364:
             board_representation_factory = RepresentationFactory[
-                ChessState, BoardModificationP, Representation364
+                ChessState, Representation364, BoardModificationP
             ](
                 create_from_state=create_from_board_364_no_bug,
                 create_from_state_and_modifications=create_from_state_and_modifications_364_no_bug,


### PR DESCRIPTION
### Motivation
- Reduce Pyright/type-inference friction by simplifying the generic parameters on the representation-to-input converter and making the factory type easier to infer.
- Keep backend-specific conversions (torch float-casting) out of the core converter by adding an optional postprocessing hook.
- Fix a stale wrapper that incorrectly wrapped a board-taking function and could cause type/runtime mismatches.

### Description
- Simplified `RepresentationBTI` generics to `RepresentationBTI[StateT, EvalIn, ModsT]` and inlined `ContentRepresentation` into the `representation_factory` parameter type as `RepresentationFactory[StateT, ContentRepresentation[StateT, EvalIn], ModsT]` in `representation_364_bti.py` and added an optional `postprocess: Callable[[EvalIn], EvalIn] | None` constructor argument used after `get_evaluator_input`.
- Changed `convert` to return `EvalIn` and apply the optional postprocess instead of hard-coding torch behavior in `representation_364_bti.py`.
- Annotated the concrete `converter` type as `RepresentationBTI[ChessState, torch.Tensor, BoardModificationP]` and pass `postprocess=lambda tensor: tensor.float()` at the torch integration point in `board_to_input.py` so torch-specific casting is applied only at the wiring layer.
- Replaced the redundant wrapper `create_chess_state_to_input` body so it simply returns `create_board_to_input(...)`, removing the incorrect intermediate wrapper that could cause a type/runtime mismatch.

### Testing
- No automated tests were executed for this patch (no `pytest` or CI run was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764413a748832bbe96dcd0bdfc9ae9)