### PR TITLE
Introduce Oracle abstraction, ChessSyzygyOracle, and pass representation factory to TreeAndValue selector

### DIFF
--- a/chipiron/players/adapters/chess_syzygy_oracle.py
+++ b/chipiron/players/adapters/chess_syzygy_oracle.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from chipiron.environments.chess.types import ChessState
+from chipiron.players.oracle import Oracle
+
+if TYPE_CHECKING:
+    from atomheart.move import MoveUci
+    from atomheart.move.imove import MoveKey
+    from valanga.game import BranchName
+
+    from chipiron.players.boardevaluators.table_base.factory import AnySyzygyTable
+
+
+class ChessSyzygyOracle(Oracle[ChessState]):
+    """Oracle wrapper around Syzygy for chess-specific best-move queries."""
+
+    def __init__(self, syzygy: AnySyzygyTable) -> None:
+        self._syzygy = syzygy
+
+    def supports(self, state: ChessState) -> bool:
+        return self._syzygy.fast_in_table(state.board)
+
+    def recommend(self, state: ChessState) -> BranchName:
+        best_move_key: MoveKey = self._syzygy.best_move(state.board)
+        best_move_uci: MoveUci = state.get_uci_from_move_key(best_move_key)
+        return best_move_uci

--- a/chipiron/players/factory.py
+++ b/chipiron/players/factory.py
@@ -16,6 +16,7 @@ from valanga import Color
 
 from chipiron.environments.chess.types import ChessState
 from chipiron.players.adapters.chess_adapter import ChessAdapter
+from chipiron.players.adapters.chess_syzygy_oracle import ChessSyzygyOracle
 from chipiron.players.boardevaluators.table_base.factory import (
     AnySyzygyTable,
     create_syzygy,
@@ -83,6 +84,7 @@ def create_chipiron_player(
         syzygy=syzygy_table,
         random_generator=random_generator,
         queue_progress_player=queue_progress_player,
+        state_type=ChessState,
     )
 
     assert main_move_selector is not None
@@ -93,10 +95,11 @@ def create_chipiron_player(
         sort_legal_moves=universal_behavior,
     )
 
+    oracle = ChessSyzygyOracle(syzygy_table) if syzygy_table is not None else None
     adapter = ChessAdapter(
         board_factory=board_factory,
         main_move_selector=main_move_selector,
-        syzygy=syzygy_table,
+        oracle=oracle,
     )
     return Player[FenPlusHistory, ChessState](name="chipiron", adapter=adapter)
 
@@ -127,6 +130,7 @@ def create_player(
         syzygy=syzygy,
         random_generator=random_generator,
         queue_progress_player=queue_progress_player,
+        state_type=ChessState,
     )
 
     board_factory: BoardFactory = create_board_factory(
@@ -135,10 +139,11 @@ def create_player(
         sort_legal_moves=universal_behavior,
     )
 
+    oracle = ChessSyzygyOracle(syzygy) if syzygy is not None else None
     adapter = ChessAdapter(
         board_factory=board_factory,
         main_move_selector=main_move_selector,
-        syzygy=syzygy,
+        oracle=oracle,
     )
 
     return Player[FenPlusHistory, ChessState](name=args.name, adapter=adapter)

--- a/chipiron/players/move_selector/factory.py
+++ b/chipiron/players/move_selector/factory.py
@@ -3,10 +3,10 @@ This module provides a factory function for creating the main move selector base
 """
 
 import random
-from typing import Type, TypeAlias
+from typing import TypeAlias, TypeVar, cast, overload
 
 from anemone import TreeAndValuePlayerArgs, create_tree_and_value_branch_selector
-from valanga import State
+from valanga import State, TurnState
 from valanga.policy import BranchSelector
 
 from chipiron.players.boardevaluators.master_board_evaluator import (
@@ -28,12 +28,39 @@ AllMoveSelectorArgs: TypeAlias = (
     | stockfish.StockfishPlayer
 )
 
+StateT = TypeVar("StateT", bound=State)
+TurnStateT = TypeVar("TurnStateT", bound=TurnState)
 
-def create_main_move_selector[StateT: State](
+
+@overload
+def create_main_move_selector(
+    move_selector_instance_or_args: TreeAndValuePlayerArgs,
+    syzygy: AnySyzygyTable | None,
+    random_generator: random.Random,
+    queue_progress_player: PutQueue[IsDataclass] | None,
+    *,
+    state_type: type[TurnStateT],
+) -> BranchSelector: ...
+
+
+@overload
+def create_main_move_selector(
     move_selector_instance_or_args: AllMoveSelectorArgs,
     syzygy: AnySyzygyTable | None,
     random_generator: random.Random,
     queue_progress_player: PutQueue[IsDataclass] | None,
+    *,
+    state_type: type[StateT] | None = None,
+) -> BranchSelector: ...
+
+
+def create_main_move_selector(
+    move_selector_instance_or_args: AllMoveSelectorArgs,
+    syzygy: AnySyzygyTable | None,
+    random_generator: random.Random,
+    queue_progress_player: PutQueue[IsDataclass] | None,
+    *,
+    state_type: type[StateT] | None = None,
 ) -> BranchSelector:
     """
     Create the main move selector based on the given arguments.
@@ -42,6 +69,7 @@ def create_main_move_selector[StateT: State](
         move_selector_instance_or_args (AllMoveSelectorArgs): The arguments or instance of the move selector.
         syzygy (AnySyzygyTable | None): The syzygy table.
         random_generator (random.Random): The random number generator.
+        state_type (type[StateT] | None): Runtime state type for the selector.
 
     Returns:
         BranchSelector: The main move selector.
@@ -58,16 +86,19 @@ def create_main_move_selector[StateT: State](
             main_move_selector = create_random(random_generator=random_generator)
         case TreeAndValuePlayerArgs():
             tree_args: TreeAndValuePlayerArgs = move_selector_instance_or_args
+            if state_type is None:
+                raise ValueError("state_type is required for TreeAndValue selectors")
+            state_type_turn = cast(type[TurnState], state_type)
             main_state_evaluator = create_master_board_evaluator(
                 board_evaluator=tree_args.board_evaluator,
                 syzygy=syzygy,
                 evaluation_scale=tree_args.evaluation_scale,
             )
             main_move_selector = create_tree_and_value_branch_selector(
-                state_type=Type(StateT),
+                state_type=state_type_turn,
                 master_state_evaluator=main_state_evaluator,
+                state_representation_factory=None,
                 args=tree_args,
-                syzygy=syzygy,
                 random_generator=random_generator,
                 queue_progress_player=queue_progress_player,
             )

--- a/chipiron/players/oracle.py
+++ b/chipiron/players/oracle.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from valanga import State
+from valanga.game import BranchName
+
+StateT = TypeVar("StateT", bound=State)
+
+
+class Oracle(Protocol[StateT]):
+    """Generic oracle for game-specific best-action queries."""
+
+    def supports(self, state: StateT) -> bool:
+        """Whether the oracle can recommend a move for this state."""
+        ...
+
+    def recommend(self, state: StateT) -> BranchName:
+        """Return the recommended branch name for the given state."""
+        ...


### PR DESCRIPTION
### Motivation
- Provide a generic, typed `Oracle` abstraction so game-specific oracles can be used uniformly by adapters and keep `TreeAndValue` selector game-agnostic.
- Wire chess Syzygy usage into an adapter-specific `ChessSyzygyOracle` so Syzygy acts as an oracle and not as evaluator knowledge.
- Fix a missing `state_representation_factory` argument when calling `create_tree_and_value_branch_selector` to match the expected anemone API and avoid runtime/type errors.

### Description
- Add a new `Oracle` protocol with a bounded `TypeVar` (`StateT = TypeVar("StateT", bound=State)`) in `chipiron/players/oracle.py` to model `supports`/`recommend` semantics.
- Introduce `ChessSyzygyOracle` in `chipiron/players/adapters/chess_syzygy_oracle.py` that wraps the Syzygy table and implements `Oracle[ChessState]`.
- Update `ChessAdapter` (`chipiron/players/adapters/chess_adapter.py`) to accept `oracle: Oracle[ChessState] | None`, replace Syzygy-specific fast-path logging with a generic oracle log, and use `oracle.supports` / `oracle.recommend`.
- Wire the chess factories (`chipiron/players/factory.py`) to pass `state_type=ChessState` into move selector creation and construct a `ChessSyzygyOracle` when a Syzygy table exists.
- Tighten and overload `create_main_move_selector` in `chipiron/players/move_selector/factory.py` to require `state_type` for `TreeAndValue` usages, cast to `TurnState`, and pass `state_representation_factory=None` into `create_tree_and_value_branch_selector` to satisfy the callee signature.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697697d74ce0832baffc3aa895cbd342)