### PR TITLE
Fix PlayerArgs typing and cast YAML-loaded player args to chess alias

### DIFF
--- a/chipiron/players/chess_player_args.py
+++ b/chipiron/players/chess_player_args.py
@@ -1,0 +1,15 @@
+"""Chess-specific player argument aliases."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from chipiron.players.move_selector.chess_tree_and_value_args import (
+    TreeAndValueChipironArgs,
+)
+from chipiron.players.move_selector.factory import NonTreeMoveSelectorArgs
+from chipiron.players.player_args import PlayerArgs, PlayerFactoryArgs
+
+ChessMoveSelectorArgs: TypeAlias = TreeAndValueChipironArgs | NonTreeMoveSelectorArgs
+ChessPlayerArgs: TypeAlias = PlayerArgs[ChessMoveSelectorArgs]
+ChessPlayerFactoryArgs: TypeAlias = PlayerFactoryArgs[ChessMoveSelectorArgs]

--- a/chipiron/players/factory_pipeline.py
+++ b/chipiron/players/factory_pipeline.py
@@ -1,0 +1,70 @@
+"""Generic player construction pipeline with game-specific builders."""
+
+from __future__ import annotations
+
+import random
+from typing import Callable, TypeVar
+
+from valanga import TurnState
+from valanga.policy import BranchSelector
+
+from chipiron.players.move_selector import factory as move_selector_factory
+from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
+from chipiron.players.oracles import PolicyOracle, TerminalOracle, ValueOracle
+from chipiron.players.player import GameAdapter, Player
+
+from ..utils.dataclass import IsDataclass
+from ..utils.queue_protocols import PutQueue
+
+SnapT = TypeVar("SnapT")
+StateT = TypeVar("StateT", bound=TurnState)
+EvalArgsT = TypeVar("EvalArgsT")
+MasterEvalT = TypeVar("MasterEvalT")
+NonTreeArgsT = TypeVar("NonTreeArgsT")
+
+
+def create_player_with_pipeline(
+    *,
+    name: str,
+    main_selector_args: TreeAndValueAppArgs[StateT, EvalArgsT] | NonTreeArgsT,
+    state_type: type[StateT],
+    policy_oracle: PolicyOracle[StateT] | None,
+    value_oracle: ValueOracle[StateT] | None,
+    terminal_oracle: TerminalOracle[StateT] | None,
+    master_evaluator_from_args: Callable[
+        [EvalArgsT, ValueOracle[StateT] | None, TerminalOracle[StateT] | None],
+        MasterEvalT,
+    ],
+    adapter_builder: Callable[
+        [BranchSelector[StateT], PolicyOracle[StateT] | None],
+        GameAdapter[SnapT, StateT],
+    ],
+    create_non_tree_selector: Callable[[NonTreeArgsT], BranchSelector[StateT]],
+    random_generator: random.Random,
+    queue_progress_player: PutQueue[IsDataclass] | None,
+) -> Player[SnapT, StateT]:
+    """Create a player using a generic selection pipeline with game-specific builders."""
+    match main_selector_args:
+        case TreeAndValueAppArgs() as tree_args:
+            master_state_evaluator = master_evaluator_from_args(
+                tree_args.evaluator_args,
+                value_oracle,
+                terminal_oracle,
+            )
+            main_move_selector: BranchSelector[StateT] = (
+                move_selector_factory.create_tree_and_value_move_selector(
+                    args=tree_args.anemone_args,
+                    state_type=state_type,
+                    master_state_evaluator=master_state_evaluator,
+                    state_representation_factory=None,
+                    random_generator=random_generator,
+                    queue_progress_player=queue_progress_player,
+                )
+            )
+        case _:
+            main_move_selector = create_non_tree_selector(
+                main_selector_args,
+            )
+
+    adapter = adapter_builder(main_move_selector, policy_oracle)
+    return Player(name=name, adapter=adapter)

--- a/chipiron/players/move_selector/__init__.py
+++ b/chipiron/players/move_selector/__init__.py
@@ -2,15 +2,10 @@
 Module for move selection in a chess game.
 """
 
-from .factory import (
-    AllMoveSelectorArgs,
-    create_main_move_selector,
-    create_tree_and_value_move_selector,
-)
+from .factory import create_main_move_selector, create_tree_and_value_move_selector
 from .stockfish import StockfishPlayer
 
 __all__ = [
-    "AllMoveSelectorArgs",
     "create_main_move_selector",
     "create_tree_and_value_move_selector",
     "StockfishPlayer",

--- a/chipiron/players/move_selector/chess_tree_and_value_args.py
+++ b/chipiron/players/move_selector/chess_tree_and_value_args.py
@@ -1,0 +1,16 @@
+"""Chess-specific tree-and-value args alias."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from chipiron.environments.chess.types import ChessState
+from chipiron.players.boardevaluators.master_board_evaluator import (
+    MasterBoardEvaluatorArgs,
+)
+
+from .tree_and_value_args import TreeAndValueAppArgs
+
+TreeAndValueChipironArgs: TypeAlias = TreeAndValueAppArgs[
+    ChessState, MasterBoardEvaluatorArgs
+]

--- a/chipiron/players/move_selector/factory.py
+++ b/chipiron/players/move_selector/factory.py
@@ -11,7 +11,7 @@ from anemone import TreeAndValuePlayerArgs, create_tree_and_value_branch_selecto
 from valanga import State, TurnState
 from valanga.policy import BranchSelector
 
-from chipiron.players.move_selector.tree_and_value_args import TreeAndValueChipironArgs
+from chipiron.environments.chess.types import ChessState
 from chipiron.utils.logger import chipiron_logger
 
 from ...utils.dataclass import IsDataclass
@@ -22,8 +22,6 @@ from .random import Random, create_random
 NonTreeMoveSelectorArgs: TypeAlias = (
     human.CommandLineHumanPlayerArgs | Random | stockfish.StockfishPlayer
 )
-
-AllMoveSelectorArgs: TypeAlias = TreeAndValueChipironArgs | NonTreeMoveSelectorArgs
 
 TurnStateT = TypeVar("TurnStateT", bound=TurnState)
 
@@ -39,7 +37,7 @@ def create_main_move_selector(
     move_selector_instance_or_args: NonTreeMoveSelectorArgs,
     *,
     random_generator: random.Random,
-) -> BranchSelector[State]:
+) -> BranchSelector[ChessState]:
     """
     Create the main move selector based on the given arguments.
 
@@ -54,7 +52,7 @@ def create_main_move_selector(
         ValueErr    or: If the given move selector instance or arguments are invalid.
 
     """
-    main_move_selector: BranchSelector[State]
+    main_move_selector: BranchSelector[ChessState]
     chipiron_logger.debug("Create main move selector")
 
     match move_selector_instance_or_args:

--- a/chipiron/players/move_selector/tree_and_value_args.py
+++ b/chipiron/players/move_selector/tree_and_value_args.py
@@ -1,0 +1,20 @@
+"""Tree-and-value move selector args with game-specific evaluator inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from anemone import TreeAndValuePlayerArgs as AnemoneTreeArgs
+from valanga import TurnState
+
+StateT = TypeVar("StateT", bound=TurnState)
+EvalArgsT = TypeVar("EvalArgsT")
+
+
+@dataclass(frozen=True)
+class TreeAndValueAppArgs(Generic[StateT, EvalArgsT]):
+    """Generic wrapper for tree-and-value settings plus evaluator args."""
+
+    anemone_args: AnemoneTreeArgs
+    evaluator_args: EvalArgsT

--- a/chipiron/players/player_args.py
+++ b/chipiron/players/player_args.py
@@ -3,23 +3,29 @@ Module for player arguments.
 """
 
 from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
 
-from . import move_selector
 from .move_selector.move_selector_types import MoveSelectorTypes
+
+class HasMoveSelectorType(Protocol):
+    type: str
+
+
+MoveSelectorArgsT = TypeVar("MoveSelectorArgsT", bound=HasMoveSelectorType)
 
 
 @dataclass
-class PlayerArgs:
+class PlayerArgs(Generic[MoveSelectorArgsT]):
     """Represents the arguments for a player.
 
     Attributes:
         name (str): The name of the player.
-        main_move_selector (move_selector.AllMoveSelectorArgs): The main move selector for the player.
+        main_move_selector (MoveSelectorArgsT): The main move selector for the player.
         syzygy_play (bool): Whether to play with syzygy when possible.
     """
 
     name: str
-    main_move_selector: move_selector.AllMoveSelectorArgs
+    main_move_selector: MoveSelectorArgsT
     syzygy_play: bool
 
     def is_human(self) -> bool:
@@ -32,7 +38,7 @@ class PlayerArgs:
 
 
 @dataclass
-class PlayerFactoryArgs:
+class PlayerFactoryArgs(Generic[MoveSelectorArgsT]):
     """A class representing the arguments for creating a player factory.
 
     Attributes:
@@ -40,5 +46,5 @@ class PlayerFactoryArgs:
         seed (int): The seed value for random number generation.
     """
 
-    player_args: PlayerArgs
+    player_args: PlayerArgs[MoveSelectorArgsT]
     seed: int

--- a/chipiron/players/player_ids.py
+++ b/chipiron/players/player_ids.py
@@ -20,10 +20,12 @@ Dependencies:
 
 from enum import Enum
 from importlib.resources import as_file, files
+from typing import cast
 
 import parsley_coco
 
-from chipiron.players import PlayerArgs
+from chipiron.players.chess_player_args import ChessPlayerArgs
+from chipiron.players.player_args import PlayerArgs
 from chipiron.utils import path
 
 
@@ -84,7 +86,7 @@ class PlayerConfigTag(str, Enum):
         with as_file(resource) as real_path:
             return str(real_path)  # Or pass it immediately to another function
 
-    def get_players_args(self) -> PlayerArgs:
+    def get_players_args(self) -> ChessPlayerArgs:
         """Get the player arguments from the YAML file.
         This method fetches the player arguments from the YAML file
         corresponding to the player's configuration tag.
@@ -98,7 +100,7 @@ class PlayerConfigTag(str, Enum):
             raise_error_with_nones=False,
             package_name=str(files("chipiron")),
         )
-        return player_args
+        return cast(ChessPlayerArgs, player_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Address type-checker complaints and potential runtime surprises when accessing `.type` on generic move-selector args by constraining the generic type parameter. 
- Make the YAML deserialization site honest to the chess-specific alias so type checkers see the correct return type for `PlayerConfigTag.get_players_args()`.

### Description
- Add `HasMoveSelectorType` `Protocol` and bound `MoveSelectorArgsT = TypeVar(..., bound=HasMoveSelectorType)` so `PlayerArgs`/`PlayerFactoryArgs` can safely access `.type` in `is_human()`; update `PlayerArgs` and `PlayerFactoryArgs` to use the generic type variable. 
- In `PlayerConfigTag.get_players_args()` use `parslay_coco.resolve_yaml_file_to_base_dataclass(..., base_cls=PlayerArgs)` at runtime and return `cast(ChessPlayerArgs, player_args)` to reconcile the runtime dataclass with the chess-specific type alias. 
- Add the `cast` import in `chipiron/players/player_ids.py` and tidy related imports to avoid typing mismatches. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778fa8a1dc832bad09126ab91f96dc)