### PR TITLE
Add move selector args union resolver and coerce PlayerArgs.main_move_selector

### DIFF
--- a/chipiron/games/game/game_args_factory.py
+++ b/chipiron/games/game/game_args_factory.py
@@ -10,7 +10,6 @@ from valanga import Color
 from valanga.game import Seed
 
 import chipiron.players as players
-from chipiron.players.player_args import HasMoveSelectorType
 from chipiron.utils.small_tools import unique_int_from_list
 
 from .game_args import GameArgs
@@ -19,7 +18,7 @@ if typing.TYPE_CHECKING:
     import chipiron.games.match as match
 
 
-class GameArgsFactory[MoveSelectorArgsT: HasMoveSelectorType]:
+class GameArgsFactory:
     """
     The GameArgsFactory creates the players and decides the rules.
     So far quite simple
@@ -28,16 +27,16 @@ class GameArgsFactory[MoveSelectorArgsT: HasMoveSelectorType]:
 
     args_match: "match.MatchSettingsArgs"
     seed_: int | None
-    args_player_one: players.PlayerArgs[MoveSelectorArgsT]
-    args_player_two: players.PlayerArgs[MoveSelectorArgsT]
+    args_player_one: players.PlayerArgs
+    args_player_two: players.PlayerArgs
     args_game: GameArgs
     game_number: int
 
     def __init__(
         self,
         args_match: "match.MatchSettingsArgs",
-        args_player_one: players.PlayerArgs[MoveSelectorArgsT],
-        args_player_two: players.PlayerArgs[MoveSelectorArgsT],
+        args_player_one: players.PlayerArgs,
+        args_player_two: players.PlayerArgs,
         seed_: int | None,
         args_game: GameArgs,
     ):
@@ -50,9 +49,7 @@ class GameArgsFactory[MoveSelectorArgsT: HasMoveSelectorType]:
 
     def generate_game_args(
         self, game_number: int
-    ) -> tuple[
-        dict[Color, players.PlayerFactoryArgs[MoveSelectorArgsT]], GameArgs, Seed | None
-    ]:
+    ) -> tuple[dict[Color, players.PlayerFactoryArgs], GameArgs, Seed | None]:
         """
         Generate game arguments for a specific game number.
 
@@ -67,20 +64,14 @@ class GameArgsFactory[MoveSelectorArgsT: HasMoveSelectorType]:
         merged_seed: Seed | None = unique_int_from_list([self.seed_, game_number])
         assert merged_seed is not None
 
-        player_one_factory_args: players.PlayerFactoryArgs[MoveSelectorArgsT] = (
-            players.PlayerFactoryArgs(
-                player_args=self.args_player_one, seed=merged_seed
-            )
+        player_one_factory_args = players.PlayerFactoryArgs(
+            player_args=self.args_player_one, seed=merged_seed
         )
-        player_two_factory_args: players.PlayerFactoryArgs[MoveSelectorArgsT] = (
-            players.PlayerFactoryArgs(
-                player_args=self.args_player_two, seed=merged_seed
-            )
+        player_two_factory_args = players.PlayerFactoryArgs(
+            player_args=self.args_player_two, seed=merged_seed
         )
 
-        player_color_to_factory_args: dict[
-            Color, players.PlayerFactoryArgs[MoveSelectorArgsT]
-        ]
+        player_color_to_factory_args: dict[Color, players.PlayerFactoryArgs]
         if game_number < self.args_match.number_of_games_player_one_white:
             player_color_to_factory_args = {
                 Color.WHITE: player_one_factory_args,

--- a/chipiron/games/game/game_manager_factory.py
+++ b/chipiron/games/game/game_manager_factory.py
@@ -29,7 +29,6 @@ from chipiron.players.boardevaluators.board_evaluator import (
     ObservableGameStateEvaluator,
 )
 from chipiron.players.factory_higher_level import MoveFunction, PlayerObserverFactory
-from chipiron.players.player_args import HasMoveSelectorType
 from chipiron.utils import path
 from chipiron.utils.communication.gui_messages.gui_messages import (
     make_players_info_payload,
@@ -79,10 +78,10 @@ class GameManagerFactory:
     session_id: SessionId = ""
     match_id: MatchId | None = None
 
-    def create[MoveSelectorArgsT: HasMoveSelectorType](
+    def create(
         self,
         args_game_manager: GameArgs,
-        player_color_to_factory_args: dict[Color, PlayerFactoryArgs[MoveSelectorArgsT]],
+        player_color_to_factory_args: dict[Color, PlayerFactoryArgs],
         game_seed: Seed,
     ) -> GameManager[Any]:
         """

--- a/chipiron/games/match/match_factories.py
+++ b/chipiron/games/match/match_factories.py
@@ -26,7 +26,6 @@ from chipiron.players.boardevaluators.factory import (
     create_game_board_evaluator_for_game_kind,
 )
 from chipiron.players.boardevaluators.table_base.factory import create_syzygy
-from chipiron.players.player_args import HasMoveSelectorType
 from chipiron.scripts.chipiron_args import ImplementationArgs
 from chipiron.scripts.script_args import BaseScriptArgs
 from chipiron.utils import path
@@ -38,17 +37,17 @@ if TYPE_CHECKING:
     import queue
 
 
-def create_match_manager[MoveSelectorArgsT: HasMoveSelectorType](
+def create_match_manager(
     args_match: MatchSettingsArgs,
-    args_player_one: players.PlayerArgs[MoveSelectorArgsT],
-    args_player_two: players.PlayerArgs[MoveSelectorArgsT],
+    args_player_one: players.PlayerArgs,
+    args_player_two: players.PlayerArgs,
     args_game: game.GameArgs,
     implementation_args: ImplementationArgs,
     universal_behavior: bool = False,
     seed: int | None = None,
     output_folder_path: path | None = None,
     gui: bool = False,
-) -> MatchManager[MoveSelectorArgsT]:
+) -> MatchManager:
     """
     Create a match manager for running matches between two players.
 
@@ -129,7 +128,7 @@ def create_match_manager[MoveSelectorArgsT: HasMoveSelectorType](
         player_one_name=player_one_name, player_two_name=player_two_name
     )
 
-    game_args_factory: game.GameArgsFactory[MoveSelectorArgsT] = game.GameArgsFactory(
+    game_args_factory = game.GameArgsFactory(
         args_match=args_match,
         args_player_one=args_player_one,
         args_player_two=args_player_two,
@@ -137,7 +136,7 @@ def create_match_manager[MoveSelectorArgsT: HasMoveSelectorType](
         args_game=args_game,
     )
 
-    match_manager: MatchManager[MoveSelectorArgsT] = MatchManager(
+    match_manager = MatchManager(
         player_one_id=player_one_name,
         player_two_id=player_two_name,
         game_manager_factory=game_manager_factory,
@@ -148,18 +147,18 @@ def create_match_manager[MoveSelectorArgsT: HasMoveSelectorType](
     return match_manager
 
 
-def create_match_manager_from_args[MoveSelectorArgsT: HasMoveSelectorType](
-    match_args: MatchArgs[MoveSelectorArgsT],
+def create_match_manager_from_args(
+    match_args: MatchArgs,
     base_script_args: BaseScriptArgs,
     implementation_args: ImplementationArgs,
     gui: bool = False,
-) -> MatchManager[MoveSelectorArgsT]:
+) -> MatchManager:
     """
     Create a match manager from the given arguments.
 
     Args:
         implementation_args(ImplementationArgs): The implementation args
-        match_args (MatchArgs[MoveSelectorArgsT]): The match arguments.
+        match_args (MatchArgs): The match arguments.
         base_script_args (ScriptArgs) The script arguments.
         gui (bool, optional): Flag indicating whether to enable GUI. Defaults to False.
 
@@ -169,8 +168,8 @@ def create_match_manager_from_args[MoveSelectorArgsT: HasMoveSelectorType](
     assert isinstance(match_args.player_one, players.PlayerArgs)
     assert isinstance(match_args.player_two, players.PlayerArgs)
 
-    player_one_args: players.PlayerArgs[MoveSelectorArgsT] = match_args.player_one
-    player_two_args: players.PlayerArgs[MoveSelectorArgsT] = match_args.player_two
+    player_one_args: players.PlayerArgs = match_args.player_one
+    player_two_args: players.PlayerArgs = match_args.player_two
 
     assert isinstance(match_args.match_setting, MatchSettingsArgs)
     assert isinstance(match_args.match_setting.game_args, game.GameArgs)
@@ -187,7 +186,7 @@ def create_match_manager_from_args[MoveSelectorArgsT: HasMoveSelectorType](
     # taking care of random
     ch.set_seeds(seed=base_script_args.seed)
 
-    match_manager: MatchManager[MoveSelectorArgsT] = create_match_manager(
+    match_manager = create_match_manager(
         args_match=match_args.match_setting,
         args_player_one=player_one_args,
         args_player_two=player_two_args,

--- a/chipiron/games/match/match_manager.py
+++ b/chipiron/games/match/match_manager.py
@@ -18,7 +18,6 @@ from chipiron.games.match.match_results import IMatchResults, MatchReport, Match
 from chipiron.games.match.match_results_factory import MatchResultsFactory
 from chipiron.games.match.observable_match_result import ObservableMatchResults
 from chipiron.players import PlayerFactoryArgs
-from chipiron.players.player_args import HasMoveSelectorType
 from chipiron.utils import path
 from chipiron.utils.logger import chipiron_logger
 
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
     from chipiron.games.game.game_manager import GameManager
 
 
-class MatchManager[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]:
+class MatchManager:
     """
     Object in charge of playing one match
 
@@ -44,7 +43,7 @@ class MatchManager[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]
         player_one_id: str,
         player_two_id: str,
         game_manager_factory: GameManagerFactory,
-        game_args_factory: GameArgsFactory[MoveSelectorArgsT],
+        game_args_factory: GameArgsFactory,
         match_results_factory: MatchResultsFactory,
         output_folder_path: path | None = None,
     ) -> None:
@@ -106,9 +105,7 @@ class MatchManager[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]
         game_number: int = 0
         while not self.game_args_factory.is_match_finished():
             args_game: GameArgs
-            player_color_to_factory_args: dict[
-                Color, PlayerFactoryArgs[MoveSelectorArgsT]
-            ]
+            player_color_to_factory_args: dict[Color, PlayerFactoryArgs]
             game_seed: Seed | None
             player_color_to_factory_args, args_game, game_seed = (
                 self.game_args_factory.generate_game_args(game_number)
@@ -188,7 +185,7 @@ class MatchManager[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]
 
     def play_one_game(
         self,
-        player_color_to_factory_args: dict[Color, PlayerFactoryArgs[MoveSelectorArgsT]],
+        player_color_to_factory_args: dict[Color, PlayerFactoryArgs],
         args_game: GameArgs,
         game_number: int,
         game_seed: Seed,

--- a/chipiron/players/chess_player_args.py
+++ b/chipiron/players/chess_player_args.py
@@ -11,5 +11,5 @@ from chipiron.players.move_selector.factory import NonTreeMoveSelectorArgs
 from chipiron.players.player_args import PlayerArgs, PlayerFactoryArgs
 
 ChessMoveSelectorArgs: TypeAlias = TreeAndValueChipironArgs | NonTreeMoveSelectorArgs
-ChessPlayerArgs: TypeAlias = PlayerArgs[ChessMoveSelectorArgs]
-ChessPlayerFactoryArgs: TypeAlias = PlayerFactoryArgs[ChessMoveSelectorArgs]
+ChessPlayerArgs: TypeAlias = PlayerArgs
+ChessPlayerFactoryArgs: TypeAlias = PlayerFactoryArgs

--- a/chipiron/players/move_selector/move_selector_args.py
+++ b/chipiron/players/move_selector/move_selector_args.py
@@ -1,14 +1,22 @@
 """
-This module defines the MoveSelectorArgs protocol for specifying arguments for MoveSelector construction.
+This module defines the MoveSelectorArgs protocol and helpers for move selector arguments.
 """
 
-from typing import Protocol
+from __future__ import annotations
 
+from dataclasses import is_dataclass
+from enum import Enum
+from typing import Any, Mapping, Protocol, TypeAlias, cast
+
+from anemone import TreeAndValuePlayerArgs
+from dacite import Config, from_dict
+
+from . import human, random, stockfish
 from .move_selector_types import MoveSelectorTypes
 
 
 class MoveSelectorArgs(Protocol):
-    """Protocol for arguments for MoveSelector construction"""
+    """Protocol for arguments for MoveSelector construction."""
 
     type: MoveSelectorTypes
 
@@ -16,6 +24,53 @@ class MoveSelectorArgs(Protocol):
         return self.type.is_human()
 
 
-class AnyMoveSelectorArgs(Protocol):
-    @property
-    def type(self) -> MoveSelectorTypes: ...
+AnyMoveSelectorArgs: TypeAlias = (
+    TreeAndValuePlayerArgs
+    | human.CommandLineHumanPlayerArgs
+    | human.GuiHumanPlayerArgs
+    | random.Random
+    | stockfish.StockfishPlayer
+)
+
+_MOVE_SELECTOR_ARGS_TYPES = (
+    TreeAndValuePlayerArgs,
+    human.CommandLineHumanPlayerArgs,
+    human.GuiHumanPlayerArgs,
+    random.Random,
+    stockfish.StockfishPlayer,
+)
+
+_MOVE_SELECTOR_ARGS_BY_TYPE: dict[MoveSelectorTypes, type[Any]] = {
+    MoveSelectorTypes.TreeAndValue: TreeAndValuePlayerArgs,
+    MoveSelectorTypes.CommandLineHuman: human.CommandLineHumanPlayerArgs,
+    MoveSelectorTypes.GuiHuman: human.GuiHumanPlayerArgs,
+    MoveSelectorTypes.Random: random.Random,
+    MoveSelectorTypes.Stockfish: stockfish.StockfishPlayer,
+}
+
+
+def resolve_move_selector_args(raw: Any) -> AnyMoveSelectorArgs:
+    """Resolve move selector args from parsed YAML/dict inputs."""
+    if isinstance(raw, _MOVE_SELECTOR_ARGS_TYPES):
+        return raw
+    if is_dataclass(raw) and hasattr(raw, "type"):
+        return cast("AnyMoveSelectorArgs", raw)
+    if isinstance(raw, Mapping):
+        selector_type = raw.get("type")
+        if selector_type is None:
+            raise ValueError("Move selector args must include a 'type' field.")
+        move_selector_type = (
+            selector_type
+            if isinstance(selector_type, MoveSelectorTypes)
+            else MoveSelectorTypes(str(selector_type))
+        )
+        target_cls = _MOVE_SELECTOR_ARGS_BY_TYPE[move_selector_type]
+        return cast(
+            "AnyMoveSelectorArgs",
+            from_dict(
+                data_class=target_cls,
+                data=dict(raw),
+                config=Config(cast=[Enum]),
+            ),
+        )
+    raise TypeError(f"Unsupported move selector args payload: {raw!r}")

--- a/chipiron/players/player_args.py
+++ b/chipiron/players/player_args.py
@@ -5,7 +5,10 @@ Module for player arguments.
 from dataclasses import dataclass
 from typing import Protocol
 
-from chipiron.players.move_selector.move_selector_args import AnyMoveSelectorArgs
+from chipiron.players.move_selector.move_selector_args import (
+    AnyMoveSelectorArgs,
+    resolve_move_selector_args,
+)
 
 from .move_selector.move_selector_types import MoveSelectorTypes
 
@@ -16,17 +19,17 @@ class HasMoveSelectorType(Protocol):
 
 
 @dataclass
-class PlayerArgs[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]:
+class PlayerArgs:
     """Represents the arguments for a player.
 
     Attributes:
         name (str): The name of the player.
-        main_move_selector (MoveSelectorArgsT): The main move selector for the player.
+        main_move_selector (AnyMoveSelectorArgs): The main move selector for the player.
         syzygy_play (bool): Whether to play with syzygy when possible.
     """
 
     name: str
-    main_move_selector: MoveSelectorArgsT
+    main_move_selector: AnyMoveSelectorArgs
     syzygy_play: bool
 
     def is_human(self) -> bool:
@@ -37,9 +40,12 @@ class PlayerArgs[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]:
         """
         return MoveSelectorTypes(self.main_move_selector.type).is_human()
 
+    def __post_init__(self) -> None:
+        self.main_move_selector = resolve_move_selector_args(self.main_move_selector)
+
 
 @dataclass
-class PlayerFactoryArgs[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelectorType]:
+class PlayerFactoryArgs:
     """A class representing the arguments for creating a player factory.
 
     Attributes:
@@ -47,8 +53,8 @@ class PlayerFactoryArgs[MoveSelectorArgsT: HasMoveSelectorType = HasMoveSelector
         seed (int): The seed value for random number generation.
     """
 
-    player_args: PlayerArgs[MoveSelectorArgsT]
+    player_args: PlayerArgs
     seed: int
 
 
-AnyPlayerArgs = PlayerArgs[AnyMoveSelectorArgs]
+AnyPlayerArgs = PlayerArgs

--- a/chipiron/utils/communication/gui_messages/gui_messages.py
+++ b/chipiron/utils/communication/gui_messages/gui_messages.py
@@ -11,12 +11,8 @@ from valanga import Color
 
 from chipiron.displays.gui_protocol import PlayerUiInfo, UpdPlayersInfo
 from chipiron.players import PlayerFactoryArgs
-from chipiron.players.player_args import HasMoveSelectorType
 
-
-def format_player_label[MoveSelectorArgsT: HasMoveSelectorType](
-    player: PlayerFactoryArgs[MoveSelectorArgsT],
-) -> str:
+def format_player_label(player: PlayerFactoryArgs) -> str:
     name: str = player.player_args.name
 
     tree_branch_limit: str | int = ""
@@ -30,8 +26,8 @@ def format_player_label[MoveSelectorArgsT: HasMoveSelectorType](
     return f"{name} ({tree_branch_limit})"
 
 
-def make_players_info_payload[MoveSelectorArgsT: HasMoveSelectorType](
-    player_color_to_factory_args: dict[Color, PlayerFactoryArgs[MoveSelectorArgsT]],
+def make_players_info_payload(
+    player_color_to_factory_args: dict[Color, PlayerFactoryArgs],
 ) -> UpdPlayersInfo:
     w = player_color_to_factory_args[Color.WHITE]
     b = player_color_to_factory_args[Color.BLACK]


### PR DESCRIPTION
### Motivation
- YAML/dataclass parsing could not instantiate `AnyMoveSelectorArgs` when it was a `Protocol`, causing `dacite`/parser failures for `PlayerArgs.main_move_selector` values.
- Provide a concrete, deterministic way to dispatch and instantiate the correct move-selector dataclass from YAML `type` fields so runtime factories can construct players reliably.

### Description
- Define `AnyMoveSelectorArgs` as a union of concrete move-selector dataclasses: `TreeAndValuePlayerArgs`, `CommandLineHumanPlayerArgs`, `GuiHumanPlayerArgs`, `Random`, and `StockfishPlayer` in `chipiron/players/move_selector/move_selector_args.py` and add `_MOVE_SELECTOR_ARGS_BY_TYPE` mapping.
- Add `resolve_move_selector_args(raw: Any) -> AnyMoveSelectorArgs` that dispatches on the `type` field and uses `dacite.from_dict` (with `Config(cast=[Enum])`) to instantiate the proper dataclass.
- Coerce `PlayerArgs.main_move_selector` at initialization by calling `resolve_move_selector_args` in `PlayerArgs.__post_init__` to ensure parsed YAML/dict inputs become concrete dataclasses.
- Update related type aliases and call sites to use the non-generic `PlayerArgs`/`PlayerFactoryArgs` and to accept `dict[Color, PlayerFactoryArgs]` (files affected include `chipiron/players/chess_player_args.py`, `chipiron/games/game/game_args_factory.py`, `chipiron/games/game/game_manager_factory.py`, `chipiron/games/match/match_factories.py`, `chipiron/games/match/match_manager.py`, and `chipiron/utils/communication/gui_messages/gui_messages.py`).

### Testing
- No automated tests were executed for this change (no test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b114eaf10832bbedd40ab9da1a98d)