### PR TITLE
Add __init__ docstrings for error classes and fix dataset collate docstring

### DIFF
--- a/chipiron/displays/gui.py
+++ b/chipiron/displays/gui.py
@@ -60,6 +60,7 @@ class GuiUpdateError(AssertionError):
     """Raised when a GUI update payload is not handled."""
 
     def __init__(self, payload: object) -> None:
+        """Initialize the error with the unhandled payload."""
         super().__init__(f"Unhandled GuiUpdate payload: {payload!r}")
 
 

--- a/chipiron/displays/gui_protocol.py
+++ b/chipiron/displays/gui_protocol.py
@@ -24,6 +24,7 @@ class UnhandledGuiProtocolValueError(GuiProtocolError):
     """Raised when an unexpected value is received in the GUI protocol."""
 
     def __init__(self, value: object) -> None:
+        """Initialize the error with the unexpected value."""
         super().__init__(f"Unhandled value: {value!r}")
 
 

--- a/chipiron/environments/chess/chess_rules.py
+++ b/chipiron/environments/chess/chess_rules.py
@@ -24,6 +24,7 @@ class UnexpectedChessResultError(ChessRulesError):
     """Raised when the board result string is not recognized."""
 
     def __init__(self, result: str, owner: str) -> None:
+        """Initialize the error with the unexpected result string."""
         super().__init__(f"unexpected result value {result} in {owner}")
 
 

--- a/chipiron/environments/chess/environment.py
+++ b/chipiron/environments/chess/environment.py
@@ -30,6 +30,7 @@ class ChessStartTagTypeError(ChessEnvironmentError):
     """Raised when an invalid start tag is provided."""
 
     def __init__(self, tag: StateTag) -> None:
+        """Initialize the error with the invalid tag."""
         super().__init__(f"Chess environment expects ChessStartTag, got {type(tag)!r}")
 
 

--- a/chipiron/environments/chess/starting_position_args.py
+++ b/chipiron/environments/chess/starting_position_args.py
@@ -20,6 +20,7 @@ class EmptyFenError(StartingPositionError):
     """Raised when a FEN string is missing."""
 
     def __init__(self) -> None:
+        """Initialize the error for a missing FEN string."""
         super().__init__("Empty fen in FenStartingPositionArgs")
 
 
@@ -27,6 +28,7 @@ class EmptyFileNameError(StartingPositionError):
     """Raised when a starting position file name is missing."""
 
     def __init__(self) -> None:
+        """Initialize the error for a missing file name."""
         super().__init__("Empty file_name in FileStartingPositionArgs")
 
 
@@ -34,6 +36,7 @@ class StartingPositionFileEmptyError(StartingPositionError):
     """Raised when a starting position file contains no data."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the error with the empty file path."""
         super().__init__(f"Starting position file is empty: {path}")
 
 
@@ -41,6 +44,7 @@ class StartingPositionFileNotFoundError(StartingPositionError):
     """Raised when a starting position file cannot be located."""
 
     def __init__(self, file_name: str) -> None:
+        """Initialize the error with the missing file name."""
         super().__init__(f"Starting position file not found: {file_name}")
 
 
@@ -48,6 +52,7 @@ class InvalidStartingPositionFileError(StartingPositionError):
     """Raised when a starting position file has invalid contents."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the error with the invalid file path."""
         super().__init__(f"Invalid starting position file: {path}")
 
 
@@ -55,6 +60,7 @@ class InvalidBoardRankError(StartingPositionError):
     """Raised when a board rank cannot be compressed to FEN."""
 
     def __init__(self, rank: str) -> None:
+        """Initialize the error with the invalid rank string."""
         super().__init__(f"Invalid board rank: {rank!r}")
 
 

--- a/chipiron/environments/environment.py
+++ b/chipiron/environments/environment.py
@@ -27,6 +27,7 @@ class EnvironmentNotFoundError(EnvironmentCreationError):
     """Raised when an environment implementation is missing."""
 
     def __init__(self, game_kind: GameKind) -> None:
+        """Initialize the error with the missing game kind."""
         super().__init__(f"No Environment for game_kind={game_kind!r}")
 
 

--- a/chipiron/games/game/game_manager_factory.py
+++ b/chipiron/games/game/game_manager_factory.py
@@ -59,6 +59,7 @@ class MissingSessionIdError(GameManagerFactoryError):
     """Raised when the session id is not provided."""
 
     def __init__(self) -> None:
+        """Initialize the error for a missing session id."""
         super().__init__("GameManagerFactory.session_id must be set")
 
 

--- a/chipiron/games/game/game_rules.py
+++ b/chipiron/games/game/game_rules.py
@@ -82,6 +82,7 @@ class MissingWinnerError(GameOutcomeError):
     """Raised when a win outcome lacks a winner."""
 
     def __init__(self) -> None:
+        """Initialize the error for a missing winner."""
         super().__init__("Winner must be provided for WIN outcomes.")
 
 
@@ -89,6 +90,7 @@ class UnhandledOutcomeKindError(GameOutcomeError):
     """Raised when an outcome kind is not handled."""
 
     def __init__(self, kind: OutcomeKind) -> None:
+        """Initialize the error with the unhandled outcome kind."""
         super().__init__(f"Unhandled outcome kind: {kind}")
 
 

--- a/chipiron/games/match/match_results.py
+++ b/chipiron/games/match/match_results.py
@@ -16,6 +16,7 @@ class InvalidMatchResultError(MatchResultsError):
     """Raised when a match result is not supported."""
 
     def __init__(self, game_result: FinalGameResult) -> None:
+        """Initialize the error with the unsupported result."""
         super().__init__(f"Unsupported game result: {game_result}")
 
 
@@ -23,6 +24,7 @@ class UnknownWhitePlayerError(MatchResultsError):
     """Raised when the white player's identity is unknown."""
 
     def __init__(self, white_player_name_id: str) -> None:
+        """Initialize the error with the unknown player id."""
         super().__init__(f"Unknown white player id: {white_player_name_id}")
 
 

--- a/chipiron/league/league.py
+++ b/chipiron/league/league.py
@@ -33,6 +33,7 @@ class LeaguePlayerSelectionError(LeagueError):
     """Raised when there are not enough players to select a match."""
 
     def __init__(self) -> None:
+        """Initialize the error for insufficient league players."""
         super().__init__(
             'Not enough players in the league. To add players put the yaml files in the folder "new players"'
         )

--- a/chipiron/learningprocesses/nn_trainer/factory.py
+++ b/chipiron/learningprocesses/nn_trainer/factory.py
@@ -54,6 +54,7 @@ class NNTrainerConfigError(ValueError):
         reuse_existing_model: bool,
         nn_parameters_file_if_reusing_existing_one: path | None,
     ) -> None:
+        """Initialize the error with inconsistent trainer arguments."""
         msg = (
             "Problem because you are asking for a reuse of existing model without specifying a"
             f" param file as we have: reuse_existing_model {reuse_existing_model}"

--- a/chipiron/players/adapters/chess_adapter.py
+++ b/chipiron/players/adapters/chess_adapter.py
@@ -24,6 +24,7 @@ class SingleLegalMoveRequiredError(ChessAdapterError):
     """Raised when only_action_name is called with multiple legal moves."""
 
     def __init__(self, move_count: int) -> None:
+        """Initialize the error with the legal move count."""
         super().__init__(
             f"only_action_name called but position has != 1 legal move (count={move_count})"
         )

--- a/chipiron/players/boardevaluators/datasets/datasets.py
+++ b/chipiron/players/boardevaluators/datasets/datasets.py
@@ -42,6 +42,7 @@ class DatasetNotLoadedError(DatasetError):
     """Raised when attempting to access an unloaded dataset."""
 
     def __init__(self) -> None:
+        """Initialize the error for an unloaded dataset."""
         super().__init__("Dataset not loaded yet. Call `load()` first.")
 
 
@@ -49,6 +50,7 @@ class UnprocessedDataUnavailableError(DatasetError):
     """Raised when unprocessed data is requested but unavailable."""
 
     def __init__(self) -> None:
+        """Initialize the error for unavailable unprocessed data."""
         super().__init__("Unprocessed data is not available.")
 
 
@@ -257,7 +259,8 @@ class FenAndValueData:
 
 
 def custom_collate_fn_fen_and_value(batch: list[FenAndValueData]) -> FenAndValueData:
-    """Custom collate function for FenAndValueData.
+    """Collate FenAndValueData items into batched tensors.
+
     Args:
         batch (list[FenAndValueData]): The batch of FenAndValueData items.
     Returns:

--- a/chipiron/players/boardevaluators/evaluation_scale.py
+++ b/chipiron/players/boardevaluators/evaluation_scale.py
@@ -38,6 +38,7 @@ class EvaluationScaleError(ValueError):
     """Raised when an unsupported evaluation scale is requested."""
 
     def __init__(self, evaluation_scale: EvaluationScale) -> None:
+        """Initialize the error with the unsupported evaluation scale."""
         super().__init__(f"Unsupported evaluation scale: {evaluation_scale}")
 
 

--- a/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -37,6 +37,7 @@ class UnexpectedGameResultError(MasterBoardEvaluatorError):
     """Raised when a game result string is not recognized."""
 
     def __init__(self, result: str) -> None:
+        """Initialize the error with the unexpected game result."""
         super().__init__(f"value {result} not expected in {__name__}")
 
 
@@ -44,6 +45,7 @@ class UnsupportedBoardEvaluatorArgsError(MasterBoardEvaluatorError):
     """Raised when board evaluator args are unsupported."""
 
     def __init__(self, args_type: str) -> None:
+        """Initialize the error with the unsupported args type."""
         super().__init__(
             f"unknown type of message received by master board evaluator {args_type} in {__name__}"
         )

--- a/chipiron/players/boardevaluators/neural_networks/chipiron_nn_args.py
+++ b/chipiron/players/boardevaluators/neural_networks/chipiron_nn_args.py
@@ -33,6 +33,7 @@ class InvalidChipironNNArgsError(ChipironNNArgsError):
     """Raised when NN args are not structured as expected."""
 
     def __init__(self, file_path: str) -> None:
+        """Initialize the error with the invalid file path."""
         super().__init__(
             f"Invalid chipiron NN args in {file_path!r}: expected mapping with string keys"
         )
@@ -42,6 +43,7 @@ class UnsupportedChipironNNArgsVersionError(ChipironNNArgsError):
     """Raised when the NN args version is unsupported."""
 
     def __init__(self, version: int) -> None:
+        """Initialize the error with the unsupported version."""
         super().__init__(f"Unsupported chipiron NN args version: {version}.")
 
 
@@ -49,6 +51,7 @@ class UnsupportedChipironNNGameKindError(ChipironNNArgsError):
     """Raised when the NN args specify an unsupported game kind."""
 
     def __init__(self, game_kind: GameKind) -> None:
+        """Initialize the error with the unsupported game kind."""
         super().__init__(f"Unsupported game_kind for now: {game_kind!r}.")
 
 

--- a/chipiron/players/boardevaluators/neural_networks/input_converters/board_to_input.py
+++ b/chipiron/players/boardevaluators/neural_networks/input_converters/board_to_input.py
@@ -40,6 +40,7 @@ class ModelInputRepresentationError(ValueError):
     """Raised when a model input representation type is unsupported."""
 
     def __init__(self, representation: ModelInputRepresentationType) -> None:
+        """Initialize the error with the unsupported representation."""
         super().__init__(f"no matching case for {representation} in {__name__}")
 
 

--- a/chipiron/players/boardevaluators/neural_networks/input_converters/representation_factory_factory.py
+++ b/chipiron/players/boardevaluators/neural_networks/input_converters/representation_factory_factory.py
@@ -21,6 +21,7 @@ class RepresentationFactoryError(ValueError):
     """Raised when a representation factory cannot be created."""
 
     def __init__(self, representation: InternalTensorRepresentationType) -> None:
+        """Initialize the error with the unsupported representation."""
         super().__init__(f"trying to create {representation} in file {__name__}")
 
 

--- a/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
+++ b/chipiron/players/boardevaluators/wirings/chess_eval_wiring.py
@@ -30,6 +30,7 @@ class ChessEvalWiringError(ValueError):
     """Raised when chess evaluator wiring receives unsupported args."""
 
     def __init__(self, args: object) -> None:
+        """Initialize the error with the unsupported args."""
         super().__init__(f"Unsupported chi args: {args!r}")
 
 

--- a/chipiron/players/communications/player_request_encoder.py
+++ b/chipiron/players/communications/player_request_encoder.py
@@ -22,6 +22,7 @@ class PlayerRequestEncoderError(ValueError):
     """Raised when a player request encoder is missing for a game kind."""
 
     def __init__(self, game_kind: GameKind) -> None:
+        """Initialize the error with the missing game kind."""
         super().__init__(f"No PlayerRequestEncoder for game_kind={game_kind!r}")
 
 

--- a/chipiron/players/move_selector/stockfish.py
+++ b/chipiron/players/move_selector/stockfish.py
@@ -53,6 +53,7 @@ class StockfishBinaryNotFoundError(StockfishError):
     """Raised when the Stockfish binary cannot be found."""
 
     def __init__(self, path: Path) -> None:
+        """Initialize the error with the missing binary path."""
         msg = (
             f"Stockfish binary not found at {path}.\n"
             "Please install Stockfish by running:\n"
@@ -67,6 +68,7 @@ class StockfishStartupError(StockfishError):
     """Raised when the Stockfish engine fails to start."""
 
     def __init__(self, path: Path, original_error: OSError) -> None:
+        """Initialize the error with the failed engine path."""
         msg = (
             f"Failed to start Stockfish engine at {path}.\n"
             "The binary may be corrupted. Try reinstalling with:\n"

--- a/chipiron/players/player.py
+++ b/chipiron/players/player.py
@@ -21,6 +21,7 @@ class PlayerMoveSelectionError(ValueError):
     """Raised when a move cannot be selected for a player."""
 
     def __init__(self) -> None:
+        """Initialize the error for missing legal moves."""
         super().__init__("No legal moves in this position")
 
 

--- a/chipiron/scripts/evaluate_models/evaluate_models.py
+++ b/chipiron/scripts/evaluate_models/evaluate_models.py
@@ -48,6 +48,7 @@ class EvaluationReportLoadError(EvaluationReportError):
     """Raised when the evaluation report cannot be loaded."""
 
     def __init__(self) -> None:
+        """Initialize the error for evaluation report loading failures."""
         super().__init__("Error loading the evaluation report")
 
 

--- a/chipiron/scripts/generate_datasets/generate_boards.py
+++ b/chipiron/scripts/generate_datasets/generate_boards.py
@@ -44,6 +44,7 @@ class DatasetDecompressionError(RuntimeError):
     """Raised when PGN decompression fails."""
 
     def __init__(self, original_error: Exception) -> None:
+        """Initialize the error with the original exception."""
         super().__init__(f"Both zstd CLI and Python zstandard failed: {original_error}")
 
 

--- a/chipiron/scripts/get_script.py
+++ b/chipiron/scripts/get_script.py
@@ -29,6 +29,7 @@ class ScriptTypeNotFoundError(KeyError):
     """Raised when a script type cannot be resolved to a script class."""
 
     def __init__(self, script_type: ScriptType) -> None:
+        """Initialize the error with the missing script type."""
         super().__init__(
             f"Cannot find the script type {script_type} in file {__name__}"
         )

--- a/chipiron/scripts/one_match/one_match.py
+++ b/chipiron/scripts/one_match/one_match.py
@@ -29,6 +29,7 @@ class OneMatchConfigError(ValueError):
     """Raised when the one-match configuration is invalid."""
 
     def __init__(self) -> None:
+        """Initialize the error for invalid one-match configuration."""
         super().__init__("Profiling does not work well atm with gui on")
 
 

--- a/chipiron/scripts/script_gui/script_gui.py
+++ b/chipiron/scripts/script_gui/script_gui.py
@@ -10,6 +10,7 @@ class ScriptGuiOptionError(ValueError):
     """Raised when a GUI option does not map to a script type."""
 
     def __init__(self, option: str) -> None:
+        """Initialize the error with the invalid GUI option."""
         super().__init__(f"Not a good name: {option}")
 
 

--- a/chipiron/utils/communication/gui_encoder_factory.py
+++ b/chipiron/utils/communication/gui_encoder_factory.py
@@ -11,6 +11,7 @@ class GuiEncoderError(ValueError):
     """Raised when a GUI encoder is missing for a game kind."""
 
     def __init__(self, game_kind: GameKind) -> None:
+        """Initialize the error with the missing game kind."""
         super().__init__(f"No GuiEncoder for game_kind={game_kind!r}")
 
 

--- a/chipiron/utils/small_tools.py
+++ b/chipiron/utils/small_tools.py
@@ -26,6 +26,7 @@ class PackageResourceNotFoundError(PackageResourceError):
     """Raised when a package resource cannot be located."""
 
     def __init__(self, relative_path: str) -> None:
+        """Initialize the error with the missing resource path."""
         super().__init__(f"Resource not found: {relative_path} in package 'chipiron'")
 
 
@@ -33,6 +34,7 @@ class PackageNotFoundError(ImportError):
     """Raised when a package cannot be found."""
 
     def __init__(self, package_name: str) -> None:
+        """Initialize the error with the missing package name."""
         super().__init__(f"Cannot find package '{package_name}'")
 
 


### PR DESCRIPTION
### Motivation
- Address many `D107` docstring lint failures by documenting `__init__` for error classes across the codebase. 
- Fix docstring formatting issues (blank line and imperative mood) for the dataset collate helper to satisfy docstring style checks.

### Description
- Added short `__init__` docstrings to numerous error/exception classes in modules such as `chipiron.displays.gui`, `chipiron.displays.gui_protocol`, `chipiron.environments.*`, `chipiron.games.*`, `chipiron.players.*`, `chipiron.scripts.*`, and `chipiron.utils.*` to make constructors documented and clear. 
- Adjusted the docstring for `custom_collate_fn_fen_and_value` in `chipiron/players/boardevaluators/datasets/datasets.py` to include the required blank line and an imperative first line. 
- Kept all changes purely documentation-focused (no functional logic changes) and kept messages short and consistent across files.

### Testing
- Ran the linter with `ruff check chipiron` and observed: All checks passed. 
- No runtime tests were altered since the changes are documentation-only and do not affect behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698607be9200832b876752e78223677e)