### PR TITLE
Fix pylint typing and import warnings

### DIFF
--- a/chipiron/players/boardevaluators/anemone_adapter.py
+++ b/chipiron/players/boardevaluators/anemone_adapter.py
@@ -8,7 +8,6 @@ from anemone.node_evaluation.node_direct_evaluation.node_direct_evaluator import
 )
 from valanga import State
 
-from chipiron.environments.chess.types import ChessState
 from chipiron.players.boardevaluators.master_board_evaluator import MasterBoardEvaluator
 
 if TYPE_CHECKING:

--- a/chipiron/players/boardevaluators/factory.py
+++ b/chipiron/players/boardevaluators/factory.py
@@ -1,6 +1,6 @@
 """Module for building game state evaluators (oracle + chipiron) with optional GUI publishing."""
 
-from typing import Any, Literal, TypeVar, assert_never, overload
+from typing import Any, Literal, assert_never, overload
 
 from chipiron.environments.chess.types import ChessState
 from chipiron.environments.types import GameKind
@@ -13,9 +13,6 @@ from .board_evaluator import (
     IGameStateEvaluator,
     ObservableGameStateEvaluator,
 )
-
-StateT = TypeVar("StateT")
-
 
 @overload
 def _select_eval_wiring(

--- a/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -10,7 +10,7 @@ from coral.neural_networks.neural_net_board_eval_args import NeuralNetBoardEvalA
 from valanga import Color
 from valanga.over_event import HowOver, OverEvent, Winner
 
-import chipiron.players.boardevaluators.basic_evaluation as basic_evaluation
+from chipiron.players.boardevaluators import basic_evaluation
 from chipiron.environments.chess.types import ChessState
 from chipiron.players.boardevaluators.all_board_evaluator_args import (
     AllBoardEvaluatorArgs,

--- a/chipiron/players/oracles.py
+++ b/chipiron/players/oracles.py
@@ -6,40 +6,40 @@ from valanga import State
 from valanga.game import BranchName
 from valanga.over_event import OverEvent
 
-StateT = TypeVar("StateT", bound=State, contravariant=True)
+StateT_contra = TypeVar("StateT_contra", bound=State, contravariant=True)
 
 
-class PolicyOracle(Protocol[StateT]):
+class PolicyOracle(Protocol[StateT_contra]):
     """Generic oracle for game-specific best-action queries."""
 
-    def supports(self, state: StateT) -> bool:
+    def supports(self, state: StateT_contra) -> bool:
         """Whether the oracle can recommend a move for this state."""
         ...
 
-    def recommend(self, state: StateT) -> BranchName:
+    def recommend(self, state: StateT_contra) -> BranchName:
         """Return the recommended branch name for the given state."""
         ...
 
 
-class ValueOracle(Protocol[StateT]):
+class ValueOracle(Protocol[StateT_contra]):
     """Generic oracle for game-specific exact evaluation."""
 
-    def supports(self, state: StateT) -> bool:
+    def supports(self, state: StateT_contra) -> bool:
         """Whether the oracle can evaluate this state."""
         ...
 
-    def value_white(self, state: StateT) -> float:
+    def value_white(self, state: StateT_contra) -> float:
         """Return the evaluation from White's perspective."""
         ...
 
 
-class TerminalOracle(Protocol[StateT]):
+class TerminalOracle(Protocol[StateT_contra]):
     """Oracle for providing terminal metadata (winner/draw)."""
 
-    def supports(self, state: StateT) -> bool:
+    def supports(self, state: StateT_contra) -> bool:
         """Whether the oracle can report a terminal outcome for this state."""
         ...
 
-    def over_event(self, state: StateT) -> OverEvent:
+    def over_event(self, state: StateT_contra) -> OverEvent:
         """Return a terminal OverEvent for the given state."""
         ...

--- a/chipiron/players/player.py
+++ b/chipiron/players/player.py
@@ -13,7 +13,7 @@ from valanga.policy import NotifyProgressCallable, Recommendation
 
 PlayerId = str
 
-StateSnapT = TypeVar("StateSnapT", contravariant=True)
+StateSnapT_contra = TypeVar("StateSnapT_contra", contravariant=True)
 RuntimeStateT = TypeVar("RuntimeStateT")
 
 
@@ -25,10 +25,10 @@ class PlayerMoveSelectionError(ValueError):
         super().__init__("No legal moves in this position")
 
 
-class GameAdapter(Protocol[StateSnapT, RuntimeStateT]):
+class GameAdapter(Protocol[StateSnapT_contra, RuntimeStateT]):
     """Game-specific behavior injected into the generic `Player`."""
 
-    def build_runtime_state(self, snapshot: StateSnapT) -> RuntimeStateT:
+    def build_runtime_state(self, snapshot: StateSnapT_contra) -> RuntimeStateT:
         """Build runtime state."""
         ...
 
@@ -54,14 +54,14 @@ class GameAdapter(Protocol[StateSnapT, RuntimeStateT]):
         ...
 
 
-class Player[StateSnapT, RuntimeStateT]:
+class Player[StateSnapT_contra, RuntimeStateT]:
     """Fully game-agnostic player: recommends an action given a snapshot."""
 
     id: PlayerId
-    adapter: GameAdapter[StateSnapT, RuntimeStateT]
+    adapter: GameAdapter[StateSnapT_contra, RuntimeStateT]
 
     def __init__(
-        self, name: str, adapter: GameAdapter[StateSnapT, RuntimeStateT]
+        self, name: str, adapter: GameAdapter[StateSnapT_contra, RuntimeStateT]
     ) -> None:
         """Initialize the instance."""
         self.id = name
@@ -73,7 +73,7 @@ class Player[StateSnapT, RuntimeStateT]:
 
     def select_move(
         self,
-        state_snapshot: StateSnapT,
+        state_snapshot: StateSnapT_contra,
         seed: Seed,
         notify_percent_function: NotifyProgressCallable | None = None,
     ) -> Recommendation:

--- a/chipiron/players/player_thread.py
+++ b/chipiron/players/player_thread.py
@@ -74,7 +74,7 @@ class PlayerProcess[SnapT, RuntimeT, BuildArgsT](multiprocessing.Process):
         we also try to send a poison-pill (`None`) into the input queue.
         """
         self._stop_event.set()
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(OSError, ValueError, RuntimeError):
             # Best-effort: if the queue is already closed or not writable, termination
             # is still handled by external process control.
             self.queue_in.put(None)
@@ -87,16 +87,14 @@ class PlayerProcess[SnapT, RuntimeT, BuildArgsT](multiprocessing.Process):
         """
         self.stop()
 
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(OSError, ValueError, RuntimeError):
             # If join isn't possible for some reason, fall back to terminate.
             self.join(timeout=1.0)
 
         if self.is_alive():
-            try:
+            with contextlib.suppress(OSError, ValueError, RuntimeError):
                 self.terminate()
                 self.join(timeout=1.0)
-            except Exception:
-                pass
 
     def run(self) -> None:
         """Run the main loop.


### PR DESCRIPTION
### Motivation
- Address pylint warnings about contravariant `TypeVar` naming and protocol generics in player/oracle code to improve static typing clarity.
- Avoid broad `except Exception` uses in process shutdown logic to prevent masking unexpected errors and satisfy linters.
- Clean up board-evaluator typing/import issues and remove unused imports to eliminate reimport/redefinition and unused-import warnings.

### Description
- Rename contravariant type variables to `StateSnapT_contra` and `StateT_contra` and update related protocol/generic annotations in `chipiron/players/player.py` and `chipiron/players/oracles.py` so `GameAdapter` and `Player` use the corrected `TypeVar` names.
- Update `Player.select_move` and `GameAdapter.build_runtime_state` signatures to use the new `TypeVar` names (`StateSnapT_contra`).
- Narrow exception handling in `chipiron/players/player_thread.py` by replacing `contextlib.suppress(Exception)` with `contextlib.suppress(OSError, ValueError, RuntimeError)` and simplify the terminate/join cleanup path.
- Clean up board-evaluator modules by removing an unused `TypeVar` declaration in `chipiron/players/boardevaluators/factory.py`, switching to `from chipiron.players.boardevaluators import basic_evaluation` in `chipiron/players/boardevaluators/master_board_evaluator.py`, and removing an unused top-level `ChessState` import from `chipiron/players/boardevaluators/anemone_adapter.py` (kept only under `TYPE_CHECKING`).

### Testing
- No automated tests or linters were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860cd93bc0832b8442dad6ab0287c0)