### PR TITLE
Update tests to import monthly PGN pipeline helpers and patch `open_month_pgn`

### DIFF
--- a/tests/scripts/generate_datasets/test_generate_boards.py
+++ b/tests/scripts/generate_datasets/test_generate_boards.py
@@ -17,8 +17,10 @@ import pytest
 
 from chipiron.scripts.generate_datasets.generate_boards import (
     generate_board_dataset_multi_months,
-    iterate_months,
     process_game,
+)
+from chipiron.scripts.generate_datasets.monthly_pgn_pipeline import (
+    iterate_months,
     save_dataset_progress,
 )
 
@@ -274,8 +276,8 @@ class TestDatasetGeneration:
 """
         return pgn_content
 
-    @patch("chipiron.scripts.generate_datasets.generate_boards.ensure_month_pgn")
-    def test_generate_board_dataset_multi_months_basic(self, mock_ensure_month):
+    @patch("chipiron.scripts.generate_datasets.monthly_pgn_pipeline.open_month_pgn")
+    def test_generate_board_dataset_multi_months_basic(self, mock_open_month_pgn):
         """Test basic multi-month dataset generation."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "test_output.pkl"
@@ -285,8 +287,8 @@ class TestDatasetGeneration:
             mock_pgn_content = self.create_mock_pgn_content(3)
             mock_pgn_path.write_text(mock_pgn_content)
 
-            # Mock the ensure_month_pgn to return our test file
-            mock_ensure_month.return_value = mock_pgn_path
+            # Mock the open_month_pgn to return our test file
+            mock_open_month_pgn.return_value = mock_pgn_path
 
             # Run dataset generation with small limits
             generate_board_dataset_multi_months(
@@ -431,12 +433,12 @@ class TestIntegration:
             pgn_content = self.create_multi_game_pgn(5)
 
             with patch(
-                "chipiron.scripts.generate_datasets.generate_boards.ensure_month_pgn"
-            ) as mock_ensure:
+                "chipiron.scripts.generate_datasets.monthly_pgn_pipeline.open_month_pgn"
+            ) as mock_open:
                 # Create mock PGN file
                 mock_pgn_path = Path(temp_dir) / "mock.pgn"
                 mock_pgn_path.write_text(pgn_content)
-                mock_ensure.return_value = mock_pgn_path
+                mock_open.return_value = mock_pgn_path
 
                 # Run complete generation
                 generate_board_dataset_multi_months(


### PR DESCRIPTION
### Motivation
- Tests were failing because `iterate_months` and `save_dataset_progress` were moved out of `generate_boards.py` into `monthly_pgn_pipeline.py`, causing `ImportError` and incorrect patch targets.
- The test-suite should import symbols from the modules that actually define them and patch the runtime lookup sites for monthly PGN download behavior.

### Description
- Updated `tests/scripts/generate_datasets/test_generate_boards.py` to import `generate_board_dataset_multi_months` and `process_game` from `generate_boards` and to import `iterate_months` and `save_dataset_progress` from `monthly_pgn_pipeline`.
- Replaced patching of `chipiron.scripts.generate_datasets.generate_boards.ensure_month_pgn` with patching of `chipiron.scripts.generate_datasets.monthly_pgn_pipeline.open_month_pgn` in the unit and integration tests so the mocked monthly PGN lookup is applied where it is called at runtime.
- Adjusted mock return usages from `mock_ensure_month.return_value` to `mock_open_month_pgn.return_value` (and `mock_open.return_value`) to return the test PGN path.
- Committed changes to the test file `tests/scripts/generate_datasets/test_generate_boards.py`.

### Testing
- No automated test run was performed as part of this change, so test execution status is `not run`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698878da3fec832ba20952cbda65e999)