### PR TITLE
Add AccelerateWhenWinning modifier, integrate into factory, and add unit tests

### DIFF
--- a/src/chipiron/players/factory_pipeline.py
+++ b/src/chipiron/players/factory_pipeline.py
@@ -67,6 +67,7 @@ def create_player_with_pipeline(
         main_move_selector = move_selector_factory.create_tree_and_value_move_selector(
             args=main_selector_args.anemone_args,
             state_type=state_type,
+            accelerate_when_winning=main_selector_args.accelerate_when_winning,
             master_state_evaluator=master_state_evaluator,
             state_representation_factory=None,
             random_generator=random_generator,

--- a/src/chipiron/players/move_selector/factory.py
+++ b/src/chipiron/players/move_selector/factory.py
@@ -11,11 +11,15 @@ from valanga import RepresentationFactory, StateModifications, TurnState
 from valanga.evaluator_types import EvaluatorInput
 from valanga.policy import BranchSelector
 
-from chipiron.environments.chess.types import ChessState
 from chipiron.players.move_selector.move_selector_args import NonTreeMoveSelectorArgs
 from chipiron.utils.logger import chipiron_logger
 
 from . import human, stockfish
+from .modifiers import (
+    AccelerateWhenWinning,
+    ComposedBranchSelector,
+    chess_progress_gain_zeroing,
+)
 from .random import Random, create_random
 
 TurnStateT = TypeVar("TurnStateT", bound=TurnState)
@@ -25,7 +29,7 @@ def create_main_move_selector(
     move_selector_instance_or_args: NonTreeMoveSelectorArgs,
     *,
     random_generator: random.Random,
-) -> BranchSelector[ChessState]:
+) -> BranchSelector[TurnState]:
     """Create the main move selector based on the given arguments.
 
     Args:
@@ -39,7 +43,7 @@ def create_main_move_selector(
         ValueErr    or: If the given move selector instance or arguments are invalid.
 
     """
-    main_move_selector: BranchSelector[ChessState]
+    main_move_selector: BranchSelector[TurnState]
     chipiron_logger.debug("Create main move selector")
 
     match move_selector_instance_or_args:
@@ -57,6 +61,7 @@ def create_tree_and_value_move_selector(
     args: TreeAndValuePlayerArgs,
     *,
     state_type: type[TurnStateT],
+    accelerate_when_winning: bool = False,
     master_state_evaluator: MasterStateEvaluator,
     state_representation_factory: (
         RepresentationFactory[TurnStateT, StateModifications, EvaluatorInput] | None
@@ -64,10 +69,21 @@ def create_tree_and_value_move_selector(
     random_generator: random.Random,
 ) -> BranchSelector[TurnStateT]:
     """Create a tree-and-value move selector with a prebuilt evaluator."""
-    return create_tree_and_value_branch_selector(
+    base_selector = create_tree_and_value_branch_selector(
         state_type=state_type,
         master_state_evaluator=master_state_evaluator,
         state_representation_factory=state_representation_factory,
         args=args,
         random_generator=random_generator,
     )
+
+    if accelerate_when_winning and hasattr(state_type, "is_zeroing"):
+        return ComposedBranchSelector(
+            base=base_selector,
+            modifiers=(
+                AccelerateWhenWinning(
+                    progress_gain_fn=chess_progress_gain_zeroing,
+                ),
+            ),
+        )
+    return base_selector

--- a/src/chipiron/players/move_selector/modifiers.py
+++ b/src/chipiron/players/move_selector/modifiers.py
@@ -1,0 +1,161 @@
+"""Composable recommendation modifiers for branch selectors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+from valanga import BranchKey, BranchName, Color, StateModifications, TurnState
+from valanga.evaluations import FloatyStateEvaluation, ForcedOutcome, StateEvaluation
+from valanga.over_event import HowOver
+from valanga.policy import BranchSelector, NotifyProgressCallable, Recommendation
+
+if TYPE_CHECKING:
+    from valanga.game import Seed
+
+TurnStateT = TypeVar("TurnStateT", bound=TurnState)
+
+
+class RecommendationModifier[StateT: TurnState](Protocol):
+    """Protocol for recommendation post-processors."""
+
+    name: str
+
+    def modify(
+        self,
+        state: StateT,
+        rec: Recommendation,
+        seed: Seed,
+    ) -> Recommendation | None:
+        """Return an overridden recommendation or ``None`` to keep the original."""
+
+
+class HasZeroing(Protocol):
+    """Capability protocol for states exposing chess zeroing detection."""
+
+    def is_zeroing(self, move: BranchKey) -> bool:
+        """Return whether a move is a zeroing move."""
+
+
+@dataclass(frozen=True, slots=True)
+class ComposedBranchSelector[StateT: TurnState](BranchSelector[StateT]):
+    """Branch selector that applies recommendation modifiers in sequence."""
+
+    base: BranchSelector[StateT]
+    modifiers: tuple[RecommendationModifier[StateT], ...] = ()
+
+    def recommend(
+        self,
+        state: StateT,
+        seed: Seed,
+        notify_progress: NotifyProgressCallable | None = None,
+    ) -> Recommendation:
+        """Recommend from base selector and then apply modifiers in order."""
+        recommendation = self.base.recommend(
+            state=state,
+            seed=seed,
+            notify_progress=notify_progress,
+        )
+        for modifier in self.modifiers:
+            overridden = modifier.modify(state=state, rec=recommendation, seed=seed)
+            if overridden is not None:
+                recommendation = overridden
+        return recommendation
+
+
+def is_winning_eval(
+    evaluation: StateEvaluation,
+    player: Color,
+    threshold: float = 0.98,
+) -> bool:
+    """Return whether ``evaluation`` is winning for ``player``."""
+    match evaluation:
+        case FloatyStateEvaluation(value_white=value_white):
+            if value_white is None:
+                return False
+            if player is Color.WHITE:
+                return value_white > threshold
+            return value_white < -threshold
+        case ForcedOutcome(outcome=outcome):
+            return outcome.how_over is HowOver.WIN and outcome.is_winner(player)
+        case _:
+            return False
+
+
+type ProgressGainFn[StateT: TurnState] = Callable[
+    [StateT, BranchName, BranchKey, StateT, StateModifications],
+    float,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AccelerateWhenWinning[StateT: TurnState]:
+    """Prefer winning branches that make more game progress."""
+
+    progress_gain_fn: ProgressGainFn[StateT]
+    name: str = "accelerate_when_winning"
+    threshold: float = 0.98
+    copy_stack: bool = False
+    deep_copy_legal_moves: bool = True
+
+    def modify(
+        self,
+        state: StateT,
+        rec: Recommendation,
+        seed: Seed,
+    ) -> Recommendation | None:
+        """Override recommendation when winning and a progress-improving move exists."""
+        if state.is_game_over():
+            return None
+        if rec.evaluation is None or rec.branch_evals is None:
+            return None
+
+        if not is_winning_eval(rec.evaluation, state.turn, threshold=self.threshold):
+            return None
+
+        best_branch: BranchName | None = None
+        best_gain: float = 0.0
+
+        for branch_name, child_eval in rec.branch_evals.items():
+            if not is_winning_eval(child_eval, state.turn, threshold=self.threshold):
+                continue
+            branch_key = state.branch_key_from_name(name=branch_name)
+            child_state = state.copy(
+                stack=self.copy_stack,
+                deep_copy_legal_moves=self.deep_copy_legal_moves,
+            )
+            mods = child_state.step(branch_key)
+            if mods is None:
+                continue
+            gain = self.progress_gain_fn(
+                state,
+                branch_name,
+                branch_key,
+                child_state,
+                mods,
+            )
+            if gain > best_gain:
+                best_gain = gain
+                best_branch = branch_name
+
+        if best_branch is None:
+            return None
+
+        return Recommendation(
+            recommended_name=best_branch,
+            evaluation=rec.evaluation,
+            policy=rec.policy,
+            branch_evals=rec.branch_evals,
+        )
+
+
+def chess_progress_gain_zeroing(
+    state: HasZeroing,
+    branch_name: BranchName,
+    branch_key: BranchKey,
+    child_state: TurnState,
+    mods: StateModifications,
+) -> float:
+    """Chess progress proxy: prefer zeroing moves (captures/pawn moves)."""
+    return 1.0 if state.is_zeroing(branch_key) else 0.0

--- a/src/chipiron/players/move_selector/tree_and_value_args.py
+++ b/src/chipiron/players/move_selector/tree_and_value_args.py
@@ -38,4 +38,5 @@ class TreeAndValueAppArgs:
 
     anemone_args: AnemoneTreeArgs
     evaluator_args: NodeEvaluatorArgs
+    accelerate_when_winning: bool = False
     type: Literal[MoveSelectorTypes.TREE_AND_VALUE] = MoveSelectorTypes.TREE_AND_VALUE

--- a/tests/players/test_move_selector_modifiers.py
+++ b/tests/players/test_move_selector_modifiers.py
@@ -1,0 +1,176 @@
+"""Unit tests for move selector recommendation modifiers."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+from valanga import BranchKey, BranchName, Color
+from valanga.evaluations import FloatyStateEvaluation
+from valanga.policy import Recommendation
+
+from chipiron.players.move_selector.modifiers import (
+    AccelerateWhenWinning,
+    ComposedBranchSelector,
+    chess_progress_gain_zeroing,
+)
+
+
+class DummySelector:
+    """Base selector stub that always returns a fixed recommendation."""
+
+    def __init__(self, rec: Recommendation) -> None:
+        """Store a fixed recommendation to return."""
+        self._rec = rec
+
+    def recommend(
+        self,
+        state: Any,
+        seed: int,
+        notify_progress: Any = None,
+    ) -> Recommendation:
+        """Return the preconfigured recommendation."""
+        _ = (state, seed, notify_progress)
+        return self._rec
+
+
+@dataclass
+class FakeTurnState:
+    """Minimal TurnState-like object for testing modifiers."""
+
+    turn: Color = Color.WHITE
+    is_over: bool = False
+    name_to_key: dict[BranchName, BranchKey] = field(default_factory=dict)
+    stepped: list[BranchKey] = field(default_factory=list)
+
+    def is_game_over(self) -> bool:
+        """Return whether this fake state is terminal."""
+        return self.is_over
+
+    def branch_key_from_name(self, name: BranchName) -> BranchKey:
+        """Map branch name to branch key."""
+        return self.name_to_key[name]
+
+    def copy(self, stack: bool, deep_copy_legal_moves: bool = True) -> FakeTurnState:
+        """Return a lightweight copy compatible with modifier expectations."""
+        _ = (stack, deep_copy_legal_moves)
+        new = copy.copy(self)
+        new.stepped = []
+        return new
+
+    def step(self, branch_key: BranchKey) -> object:
+        """Record a step and return a non-None placeholder modification."""
+        self.stepped.append(branch_key)
+        return object()
+
+
+@dataclass
+class FakeChessState(FakeTurnState):
+    """Adds the chess capability needed by chess_progress_gain_zeroing."""
+
+    zeroing_keys: set[BranchKey] = field(default_factory=set)
+
+    def is_zeroing(self, move: BranchKey) -> bool:
+        """Return whether a branch key is considered zeroing in this fake state."""
+        return move in self.zeroing_keys
+
+
+def test_accelerate_when_not_winning_does_not_override() -> None:
+    """Modifier should not alter recommendation when root eval is not winning."""
+    state = FakeChessState(
+        turn=Color.WHITE,
+        name_to_key={"a": 1, "b": 2},
+        zeroing_keys={2},
+    )
+    rec = Recommendation(
+        recommended_name="a",
+        evaluation=FloatyStateEvaluation(value_white=0.2),
+        branch_evals={
+            "a": FloatyStateEvaluation(value_white=0.2),
+            "b": FloatyStateEvaluation(value_white=0.99),
+        },
+    )
+    selector = ComposedBranchSelector(
+        base=DummySelector(rec),
+        modifiers=(AccelerateWhenWinning(progress_gain_fn=chess_progress_gain_zeroing),),
+    )
+
+    out = selector.recommend(state=state, seed=0)
+
+    assert out.recommended_name == "a"
+
+
+def test_accelerate_when_winning_prefers_zeroing_move_that_stays_winning() -> None:
+    """When winning, modifier should prefer a winning child with higher progress gain."""
+    state = FakeChessState(
+        turn=Color.WHITE,
+        name_to_key={"a": 1, "b": 2},
+        zeroing_keys={2},
+    )
+    rec = Recommendation(
+        recommended_name="a",
+        evaluation=FloatyStateEvaluation(value_white=0.99),
+        branch_evals={
+            "a": FloatyStateEvaluation(value_white=0.99),
+            "b": FloatyStateEvaluation(value_white=0.99),
+        },
+    )
+    selector = ComposedBranchSelector(
+        base=DummySelector(rec),
+        modifiers=(AccelerateWhenWinning(progress_gain_fn=chess_progress_gain_zeroing),),
+    )
+
+    out = selector.recommend(state=state, seed=0)
+
+    assert out.recommended_name == "b"
+
+
+def test_accelerate_when_winning_does_not_choose_non_winning_child() -> None:
+    """Modifier should not pick a progress move that loses the winning eval filter."""
+    state = FakeChessState(
+        turn=Color.WHITE,
+        name_to_key={"a": 1, "b": 2},
+        zeroing_keys={2},
+    )
+    rec = Recommendation(
+        recommended_name="a",
+        evaluation=FloatyStateEvaluation(value_white=0.99),
+        branch_evals={
+            "a": FloatyStateEvaluation(value_white=0.99),
+            "b": FloatyStateEvaluation(value_white=0.0),
+        },
+    )
+    selector = ComposedBranchSelector(
+        base=DummySelector(rec),
+        modifiers=(AccelerateWhenWinning(progress_gain_fn=chess_progress_gain_zeroing),),
+    )
+
+    out = selector.recommend(state=state, seed=0)
+
+    assert out.recommended_name == "a"
+
+
+def test_accelerate_when_winning_no_override_when_best_gain_is_zero() -> None:
+    """Modifier should keep base recommendation when no positive gain exists."""
+    state = FakeChessState(
+        turn=Color.WHITE,
+        name_to_key={"a": 1, "b": 2},
+        zeroing_keys=set(),
+    )
+    rec = Recommendation(
+        recommended_name="a",
+        evaluation=FloatyStateEvaluation(value_white=0.99),
+        branch_evals={
+            "a": FloatyStateEvaluation(value_white=0.99),
+            "b": FloatyStateEvaluation(value_white=0.99),
+        },
+    )
+    selector = ComposedBranchSelector(
+        base=DummySelector(rec),
+        modifiers=(AccelerateWhenWinning(progress_gain_fn=chess_progress_gain_zeroing),),
+    )
+
+    out = selector.recommend(state=state, seed=0)
+
+    assert out.recommended_name == "a"


### PR DESCRIPTION
### Motivation
- Introduce a composable recommendation modifier to prefer progress-making moves when the root position is already winning, so tree-and-value selectors can "accelerate" finishing sequences without changing core MCTS logic. 
- Make the modifier opt-in from the tree-and-value args and pipeline so callers can enable the behavior per-player configuration. 
- Provide focused unit tests that validate modifier behavior without spinning up anemone/MCTS or other heavy subsystems.

### Description
- Add `src/chipiron/players/move_selector/modifiers.py` which implements `ComposedBranchSelector`, `AccelerateWhenWinning`, `is_winning_eval`, and `chess_progress_gain_zeroing` as a chess-specific progress proxy. 
- Update `src/chipiron/players/move_selector/factory.py` to accept `accelerate_when_winning` in `create_tree_and_value_move_selector` and wrap the base selector with `ComposedBranchSelector` + `AccelerateWhenWinning` when enabled and the state exposes `is_zeroing`. 
- Add `accelerate_when_winning: bool = False` to `TreeAndValueAppArgs` in `src/chipiron/players/move_selector/tree_and_value_args.py` and forward the flag from the higher-level pipeline in `src/chipiron/players/factory_pipeline.py`. 
- Add focused unit tests at `tests/players/test_move_selector_modifiers.py` using small fakes (`DummySelector`, `FakeTurnState`, `FakeChessState`) that cover: no override when not winning, override to a zeroing move when winning (if child remains winning), not overriding to a losing child, and not overriding when best gain is zero.

### Testing
- Ran `ruff check` against the new test and modified files and the linter passed. 
- Attempted to run the new test file with `pytest` in this environment, but collection failed with `ModuleNotFoundError: No module named 'valanga'` because the test runtime here lacks the external `valanga` dependency; the tests are unit-only and should pass in CI or a developer environment where `valanga` is installed. 
- The new tests are lightweight and exercise the modifier logic without requiring anemone/MCTS or full game stacks, so they should be stable in normal test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b84d76fb0832bb95045a2ccb92923)