### PR TITLE
Harden PV tactical priority check with stronger typing and open-branch guard

### DIFF
--- a/src/chipiron/data/players/player_config/chipiron/chipiron.yaml
+++ b/src/chipiron/data/players/player_config/chipiron/chipiron.yaml
@@ -7,7 +7,11 @@ main_move_selector:
     node_selector:
       type: Composed
       priority:
-        type: PriorityNoop
+        type: PriorityRegistered
+        name: pv_attacked_open_all
+        params:
+          probability: 0.5
+          feature_key: tactical_threat
       base:
         type: RecurZipfBase
         branch_explorer_priority: priority_best

--- a/src/chipiron/players/move_selector/priority_checks/__init__.py
+++ b/src/chipiron/players/move_selector/priority_checks/__init__.py
@@ -1,0 +1,1 @@
+"""Priority checks for tree-and-value node opening."""

--- a/src/chipiron/players/move_selector/priority_checks/pv_attacked_open_all.py
+++ b/src/chipiron/players/move_selector/priority_checks/pv_attacked_open_all.py
@@ -1,0 +1,74 @@
+"""Priority check opening all branches when the principal variation is tactically attacked."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from anemone.hooks.search_hooks import FeatureExtractor
+from anemone.node_selector.opening_instructions import (
+    OpeningInstructor,
+    OpeningInstructions,
+    create_instructions_to_open_all_branches,
+)
+from anemone.nodes.algorithm_node.algorithm_node import AlgorithmNode
+
+if TYPE_CHECKING:
+    from anemone.trees import Tree
+
+
+def _deepest_existing_node_on_pv(root: AlgorithmNode[Any]) -> AlgorithmNode[Any]:
+    """Return the deepest already-expanded node along the current PV sequence."""
+    node: AlgorithmNode[Any] = root
+    best_branch_sequence = getattr(root.tree_evaluation, "best_branch_sequence", ())
+
+    for branch in best_branch_sequence:
+        child = node.branches_children.get(branch)
+        if child is None:
+            break
+        node = child
+
+    return node
+
+
+@dataclass(frozen=True)
+class PvAttackedOpenAllPriorityCheck:
+    """Open all branches at the current PV node when it is tactically threatened."""
+
+    opening_instructor: OpeningInstructor
+    feature_extractor: FeatureExtractor | None
+    random_generator: random.Random
+    probability: float = 0.5
+    feature_key: str = "tactical_threat"
+
+    def maybe_choose_opening(
+        self,
+        tree: "Tree[AlgorithmNode[Any]]",
+        latest_tree_expansions: Any,
+    ) -> OpeningInstructions[AlgorithmNode[Any]] | None:
+        """Optionally return opening instructions that override the base selector."""
+        _ = latest_tree_expansions
+
+        if self.feature_extractor is None:
+            return None
+
+        target = _deepest_existing_node_on_pv(tree.root_node)
+        if target.is_over():
+            return None
+
+        if self.probability < 1.0 and self.random_generator.random() > self.probability:
+            return None
+
+        features = self.feature_extractor.features(target.state)
+        if not bool(features.get(self.feature_key, False)):
+            return None
+
+        if not target.non_opened_branches:
+            return None
+
+        branches_to_open = self.opening_instructor.all_branches_to_open(target)
+        return create_instructions_to_open_all_branches(
+            branches_to_play=branches_to_open,
+            node_to_open=target,
+        )


### PR DESCRIPTION
### Motivation
- Make the PV-attacked priority check more robust and clearer to linters by tightening types and preventing redundant overrides when there are no branches left to open.
- Wire the check into the move-selector factory so it can be activated via configuration and tested in the factory wiring scenario.
- Make the factory wiring test future-proof so it won't crash if the test later exercises `maybe_choose_opening`.

### Description
- Change `PvAttackedOpenAllPriorityCheck.random_generator` from `Any` to `random.Random` and keep `Tree` imported only under `TYPE_CHECKING` to avoid runtime import issues.
- Add a guard `if not target.non_opened_branches: return None` to skip the override when there is nothing left to open, and preserve the PV-targeting logic using `AlgorithmNode`.
- Add `pv_attacked_open_all_factory` in `create_tree_and_value_move_selector` with the signature `params: Mapping[str, Any]` and register it in `SearchHooks.priority_check_registry` under the name `pv_attacked_open_all`.
- Introduce a minimal `DummyOpeningInstructor` stub in the factory wiring test and assert the registry contains the factory and produces a `PvAttackedOpenAllPriorityCheck` with the expected parameters.

### Testing
- Successfully byte-compiled changed modules with `python -m py_compile src/chipiron/players/move_selector/priority_checks/pv_attacked_open_all.py src/chipiron/players/move_selector/factory.py src/chipiron/players/move_selector/test_factory_hooks.py`.
- Ran `pytest -q -o addopts='' src/chipiron/players/move_selector/test_factory_hooks.py` and collection failed due to the container Python (3.10) being unable to parse unrelated Python 3.13-only syntax elsewhere in the repository, so the failure is environmental and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de13534a4832ba74ddbb54a4ed9a2)