### PR TITLE
Thread Dynamics into runtime and harden SearchDynamics boundary for chess

### DIFF
--- a/src/chipiron/environments/base.py
+++ b/src/chipiron/environments/base.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, TypeVar
 
-from valanga import StateTag
+from valanga import Dynamics, StateTag
 
 from chipiron.environments.types import GameKind
 from chipiron.games.game.game_rules import GameRules
@@ -60,6 +60,7 @@ class Environment[StateT, StateSnapT, StartTagT]:
 
     game_kind: GameKind
     rules: GameRules[StateT]
+    dynamics: Dynamics[StateT]
     gui_encoder: GuiEncoder[StateT]
     player_encoder: PlayerRequestEncoder[StateT, StateSnapT]
     make_player_observer_factory: PlayerObserverFactoryBuilder

--- a/src/chipiron/environments/chess/chess_rules.py
+++ b/src/chipiron/environments/chess/chess_rules.py
@@ -36,7 +36,7 @@ class ChessRules(GameRules[ChessState]):
 
     def outcome(self, state: ChessState) -> GameOutcome | None:
         """Outcome."""
-        if state.is_game_over():
+        if state.board.is_game_over():
             return self._outcome_from_board(state)
         return None
 
@@ -44,7 +44,7 @@ class ChessRules(GameRules[ChessState]):
         """Pretty result."""
         result_str = self._result_string_outcome(outcome)
         reason = outcome.reason
-        if reason is None and state.is_game_over():
+        if reason is None and state.board.is_game_over():
             reason = self._termination_reason(state)
         message = f"Result: {result_str}"
         if reason:
@@ -53,9 +53,9 @@ class ChessRules(GameRules[ChessState]):
 
     def assessment(self, state: ChessState) -> PositionAssessment | None:
         """Assessment."""
-        if self.syzygy is None or not self.syzygy.fast_in_table(state):
+        if self.syzygy is None or not self.syzygy.fast_in_table(state.board):
             return None
-        winner, how_over = self.syzygy.get_over_event(board=state)
+        winner, how_over = self.syzygy.get_over_event(board=state.board)
         return self._assessment_from_over_event(winner, how_over, reason="syzygy")
 
     def pretty_assessment(
@@ -66,14 +66,14 @@ class ChessRules(GameRules[ChessState]):
         message = f"Assessment: {result_str}"
         if assessment.reason:
             message = f"{message} ({assessment.reason})"
-        if self.syzygy is not None and self.syzygy.fast_in_table(state):
-            syzygy_str = self.syzygy.string_result(state)
+        if self.syzygy is not None and self.syzygy.fast_in_table(state.board):
+            syzygy_str = self.syzygy.string_result(state.board)
             message = f"{message} | Syzygy: {syzygy_str}"
         return message
 
     def _outcome_from_board(self, state: ChessState) -> GameOutcome:
         """Derive a GameOutcome from the current board result."""
-        result = state.result(claim_draw=True)
+        result = state.board.result(claim_draw=True)
         reason = self._termination_reason(state)
         match result:
             case "1-0":
@@ -135,7 +135,7 @@ class ChessRules(GameRules[ChessState]):
     @staticmethod
     def _termination_reason(state: ChessState) -> str | None:
         """Return a termination reason string when the game is over."""
-        termination = state.termination()
+        termination = state.board.termination()
         if termination is None:
             return None
         return str(termination)

--- a/src/chipiron/environments/chess/environment.py
+++ b/src/chipiron/environments/chess/environment.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from atomheart import ValangaChessState
+from atomheart import ChessDynamics
 from atomheart.board.utils import FenPlusHistory
 from valanga import StateTag
 
@@ -60,13 +60,16 @@ def make_chess_environment(
         return tag
 
     def make_initial_state(tag: ChessStartTag) -> ChessState:
-        return ValangaChessState(
+        return ChessState(
             deps.board_factory(fen_with_history=FenPlusHistory(current_fen=tag.fen))
         )
+
+    dynamics = ChessDynamics()
 
     return Environment(
         game_kind=GameKind.CHESS,
         rules=ChessRules(syzygy=deps.syzygy_table),
+        dynamics=dynamics,
         gui_encoder=ChessGuiEncoder(),
         player_encoder=ChessPlayerRequestEncoder(),
         make_player_observer_factory=build_player_observer_factory,

--- a/src/chipiron/environments/chess/search_dynamics.py
+++ b/src/chipiron/environments/chess/search_dynamics.py
@@ -1,0 +1,53 @@
+"""Depth-aware chess search dynamics."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from anemone.dynamics import SearchDynamics
+from atomheart.move.imove import MoveKey
+from valanga import Transition
+
+from chipiron.environments.chess.types import ChessState
+
+
+@dataclass(frozen=True)
+class ChessSearchDynamics(SearchDynamics[ChessState]):
+    """Search dynamics with depth-aware board-copy policy."""
+
+    copy_stack_until_depth: int = 2
+    deep_copy_legal_moves: bool = True
+
+    def legal_actions(self, state: ChessState) -> Any:
+        """Return legal action collection for ``state``."""
+        return state.board.legal_moves
+
+    def action_name(self, state: ChessState, action: MoveKey) -> str:
+        """Convert an action key to a stable branch name."""
+        return state.board.get_uci_from_move_key(move_key=action)
+
+    def action_from_name(self, state: ChessState, name: str) -> MoveKey:
+        """Convert a stable branch name to an action key."""
+        return state.board.get_move_key_from_uci(move_uci=name)
+
+    def step(
+        self,
+        state: ChessState,
+        action: MoveKey,
+        *,
+        depth: int = 0,
+    ) -> Transition[ChessState]:
+        """Apply ``action`` and return a transition using depth-aware copy behavior."""
+        copy_stack = depth < self.copy_stack_until_depth
+        board_copy = state.board.copy(
+            stack=copy_stack,
+            deep_copy_legal_moves=self.deep_copy_legal_moves,
+        )
+        _ = board_copy.play_move_key(move=action)
+        next_state = ChessState(board_copy)
+        return Transition(
+            next_state=next_state,
+            modifications=None,
+            is_over=board_copy.is_game_over(),
+            over_event=None,
+            info={},
+        )

--- a/src/chipiron/environments/chess/types.py
+++ b/src/chipiron/environments/chess/types.py
@@ -1,5 +1,5 @@
 """Shared chess type aliases."""
 
-from atomheart.board.valanga_adapter import ValangaChessState
+from atomheart import ChessState as AtomheartChessState
 
-ChessState = ValangaChessState
+ChessState = AtomheartChessState

--- a/src/chipiron/environments/search_dynamics.py
+++ b/src/chipiron/environments/search_dynamics.py
@@ -1,0 +1,26 @@
+"""Helpers for choosing SearchDynamics adapters from runtime environment dynamics."""
+
+from anemone.dynamics import SearchDynamics, StatelessDynamicsAdapter
+from typing import Any
+
+from valanga import Dynamics
+
+from chipiron.environments.chess.search_dynamics import ChessSearchDynamics
+from chipiron.environments.types import GameKind
+
+
+def make_search_dynamics(
+    *,
+    game_kind: GameKind,
+    dynamics: Dynamics[Any],
+    copy_stack_until_depth: int = 2,
+    deep_copy_legal_moves: bool = True,
+) -> SearchDynamics[Any]:
+    """Build search dynamics for Anemone from game runtime dynamics."""
+    if game_kind is GameKind.CHESS:
+        return ChessSearchDynamics(
+            copy_stack_until_depth=copy_stack_until_depth,
+            deep_copy_legal_moves=deep_copy_legal_moves,
+        )
+
+    return StatelessDynamicsAdapter(dynamics)

--- a/src/chipiron/games/game/game_manager_factory.py
+++ b/src/chipiron/games/game/game_manager_factory.py
@@ -157,7 +157,7 @@ class GameManagerFactory:
 
         start_tag = args_game_manager.starting_position.get_start_tag()
         normalized_start_tag = environment.normalize_start_tag(start_tag)
-        board = environment.make_initial_state(normalized_start_tag)
+        state = environment.make_initial_state(normalized_start_tag)
         for publisher in publishers:
             payload = make_players_info_payload(
                 player_color_to_factory_args=player_color_to_factory_args
@@ -172,7 +172,8 @@ class GameManagerFactory:
 
         game = Game(
             playing_status=game_playing_status,
-            state=board,
+            state=state,
+            dynamics=environment.dynamics,
             seed_=game_seed,
         )
 

--- a/src/chipiron/games/game/test_game.py
+++ b/src/chipiron/games/game/test_game.py
@@ -4,7 +4,9 @@ import chess
 import pytest
 from atomheart.board import IBoard, create_board
 from atomheart.board.utils import FenPlusHistory
-from atomheart.board.valanga_adapter import ValangaChessState
+
+from chipiron.environments.chess.types import ChessState
+from atomheart import ChessDynamics
 
 from chipiron.games.game import Game
 from chipiron.games.game.game_playing_status import GamePlayingStatus
@@ -18,32 +20,33 @@ def test_game_rewind(use_rust_boards: bool) -> None:
         fen_with_history=FenPlusHistory(current_fen=chess.STARTING_FEN),
     )
 
-    state = ValangaChessState(board=board)
+    state = ChessState(board=board)
 
     game_playing_status: GamePlayingStatus = GamePlayingStatus()
 
-    game: Game = Game(state=state, playing_status=game_playing_status)
+    dynamics = ChessDynamics()
+    game: Game = Game(state=state, dynamics=dynamics, playing_status=game_playing_status)
 
     game.playing_status.pause()
     game.rewind_one_move()
 
     game.playing_status.play()
-    game.play_move(action=game.state.branch_key_from_name("e2e4"))
+    game.play_move(action=game.dynamics.action_from_name(game.state, "e2e4"))
 
     game.playing_status.pause()
     game.rewind_one_move()
 
     game.playing_status.play()
-    game.play_move(action=game.state.branch_key_from_name("e2e4"))
+    game.play_move(action=game.dynamics.action_from_name(game.state, "e2e4"))
 
     game.playing_status.play()
-    game.play_move(action=game.state.branch_key_from_name("g8f6"))
+    game.play_move(action=game.dynamics.action_from_name(game.state, "g8f6"))
 
     game.playing_status.pause()
     game.rewind_one_move()
 
     game.playing_status.play()
-    game.play_move(action=game.state.branch_key_from_name("g8f6"))
+    game.play_move(action=game.dynamics.action_from_name(game.state, "g8f6"))
 
 
 if __name__ == "__main__":

--- a/src/chipiron/players/adapters/chess_adapter.py
+++ b/src/chipiron/players/adapters/chess_adapter.py
@@ -57,15 +57,15 @@ class ChessAdapter:
     def legal_action_count(self, runtime_state: ChessState) -> int:
         # Keep the API generic; for chess we count legal moves.
         """Legal action count."""
-        return len(runtime_state.legal_moves.get_all())
+        return len(runtime_state.board.legal_moves.get_all())
 
     def only_action_name(self, runtime_state: ChessState) -> BranchName:
         """Only action name."""
-        keys = runtime_state.legal_moves.get_all()
+        keys = runtime_state.board.legal_moves.get_all()
         if len(keys) != 1:
             raise SingleLegalMoveRequiredError(len(keys))
         move_key: MoveKey = keys[0]
-        move_uci: MoveUci = runtime_state.get_uci_from_move_key(move_key)
+        move_uci: MoveUci = runtime_state.board.get_uci_from_move_key(move_key)
         return move_uci
 
     def oracle_action_name(self, runtime_state: ChessState) -> BranchName | None:

--- a/src/chipiron/players/factory_pipeline.py
+++ b/src/chipiron/players/factory_pipeline.py
@@ -4,7 +4,8 @@ import random
 from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar
 
-from valanga import TurnState
+from anemone.dynamics import SearchDynamics
+from valanga import Dynamics, TurnState
 from valanga.policy import BranchSelector
 
 from chipiron.players.boardevaluators.master_board_evaluator import (
@@ -56,6 +57,9 @@ def create_player_with_pipeline(
         [NonTreeMoveSelectorArgs], BranchSelector[StateT]
     ],
     random_generator: random.Random,
+    dynamics: Dynamics[StateT] | SearchDynamics[StateT],
+    copy_stack_until_depth: int = 2,
+    deep_copy_legal_moves: bool = True,
 ) -> Player[SnapT, StateT]:
     """Create a player using a generic selection pipeline with game-specific builders."""
     if isinstance(main_selector_args, TreeAndValueAppArgs):
@@ -71,6 +75,9 @@ def create_player_with_pipeline(
             master_state_evaluator=master_state_evaluator,
             state_representation_factory=None,
             random_generator=random_generator,
+            copy_stack_until_depth=copy_stack_until_depth,
+            deep_copy_legal_moves=deep_copy_legal_moves,
+            dynamics=dynamics,
         )
     elif isinstance(main_selector_args, GuiHumanPlayerArgs):
         # Minimal behavior: fail fast with a clear message (or implement GUI path)


### PR DESCRIPTION
### Motivation
- Centralize and surface runtime `Dynamics` so Anemone receives the correct `SearchDynamics` adapter and runtime code no longer relies on ad-hoc state APIs.  
- Make chess tree-search copy policy robust to return-value/typing differences from Atomheart/board mutation APIs so tree expansion sees a consistent `Transition` payload.

### Description
- Thread `Dynamics` into the environment and game stack by adding `dynamics` to `Environment` and requiring `Game(..., dynamics=...)`, and expose `game.dynamics` and `observable_game.dynamics` for callers (files: `environments/base.py`, `games/game/game.py`, `games/game/game_manager_factory.py`, `environments/chess/environment.py`).
- Add `make_search_dynamics(...)` to choose Anemone `SearchDynamics` adapters (chess => `ChessSearchDynamics`, other => `StatelessDynamicsAdapter`) and relax the generic typing to an `Any`-based adapter boundary to avoid brittle casts (file: `environments/search_dynamics.py`).
- Implement `ChessSearchDynamics` with depth-aware copy policy and make its `step(...)` emit a stable `Transition(..., modifications=None, ...)` while still producing a proper `next_state` and terminal flag (file: `environments/chess/search_dynamics.py`).
- Update chess runtime callers to use `state.board.*` accessors (syzygy, termination, result, legal moves, UCI conversions) and switch chess state alias to `atomheart.ChessState` (files: `environments/chess/chess_rules.py`, `environments/chess/types.py`, `players/adapters/chess_adapter.py`).
- Wire `make_search_dynamics(...)` into player construction and tree factory code so Anemone components get the correct `SearchDynamics`, and propagate `dynamics`, `copy_stack_until_depth`, and `deep_copy_legal_moves` through `create_player_with_pipeline`, `move_selector.factory`, `create_random`, and modifier plumbing (`players/factory.py`, `players/factory_pipeline.py`, `players/move_selector/factory.py`, `players/move_selector/random.py`, `players/move_selector/modifiers.py`).

### Testing
- Ran `git diff --check` which passed.  
- Ran `pytest -q -o addopts='' src/chipiron/games/game/test_game.py` which failed during collection with a `SyntaxError` caused by this runtime using Python 3.10 while the repository contains Python 3.12-style `type` alias syntax, preventing unit test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a9327760832b87dc9f3cc605119a)