### PR TITLE
Finalize SearchDynamics generic cleanup and fix missing-dynamics exception

### DIFF
--- a/src/chipiron/environments/chess/search_dynamics.py
+++ b/src/chipiron/environments/chess/search_dynamics.py
@@ -11,8 +11,10 @@ from chipiron.environments.chess.types import ChessState
 
 
 @dataclass(frozen=True)
-class ChessSearchDynamics(SearchDynamics[ChessState]):
+class ChessSearchDynamics(SearchDynamics[ChessState, MoveKey]):
     """Search dynamics with depth-aware board-copy policy."""
+
+    __anemone_search_dynamics__ = True
 
     copy_stack_until_depth: int = 2
     deep_copy_legal_moves: bool = True

--- a/src/chipiron/environments/search_dynamics.py
+++ b/src/chipiron/environments/search_dynamics.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from anemone.dynamics import SearchDynamics, StatelessDynamicsAdapter
+from anemone.dynamics import SearchDynamics, normalize_search_dynamics
 from valanga import Dynamics
 
 from chipiron.environments.chess.search_dynamics import ChessSearchDynamics
@@ -15,7 +15,7 @@ def make_search_dynamics(
     dynamics: Dynamics[Any],
     copy_stack_until_depth: int = 2,
     deep_copy_legal_moves: bool = True,
-) -> SearchDynamics[Any]:
+) -> SearchDynamics[Any, Any]:
     """Build search dynamics for Anemone from game runtime dynamics."""
     if game_kind is GameKind.CHESS:
         return ChessSearchDynamics(
@@ -23,4 +23,4 @@ def make_search_dynamics(
             deep_copy_legal_moves=deep_copy_legal_moves,
         )
 
-    return StatelessDynamicsAdapter(dynamics)
+    return normalize_search_dynamics(dynamics)

--- a/src/chipiron/players/factory.py
+++ b/src/chipiron/players/factory.py
@@ -14,9 +14,8 @@ from atomheart.board.utils import FenPlusHistory
 from valanga import Color
 from valanga.policy import BranchSelector
 
+from chipiron.environments.chess.search_dynamics import ChessSearchDynamics
 from chipiron.environments.chess.types import ChessState
-from chipiron.environments.search_dynamics import make_search_dynamics
-from chipiron.environments.types import GameKind
 from chipiron.players.adapters.chess_adapter import ChessAdapter
 from chipiron.players.adapters.chess_syzygy_oracle import (
     ChessSyzygyPolicyOracle,
@@ -216,9 +215,7 @@ def create_chess_player(
     deep_copy_legal_moves = bool(getattr(search_config, "deep_copy_legal_moves", True))
 
     chess_dynamics = ChessDynamics()
-    chess_search_dynamics = make_search_dynamics(
-        game_kind=GameKind.CHESS,
-        dynamics=chess_dynamics,
+    chess_search_dynamics = ChessSearchDynamics(
         copy_stack_until_depth=copy_stack_until_depth,
         deep_copy_legal_moves=deep_copy_legal_moves,
     )
@@ -232,15 +229,16 @@ def create_chess_player(
         terminal_oracle=terminal_oracle,
         master_evaluator_from_args=master_evaluator_from_args,
         adapter_builder=adapter_builder,
-        create_non_tree_selector=lambda selector_args: (
+        create_non_tree_selector=lambda selector_args, dynamics: (
             move_selector.create_main_move_selector(
                 selector_args,
-                dynamics=chess_dynamics,
+                dynamics=dynamics,
                 random_generator=random_generator,
             )
         ),
         random_generator=random_generator,
-        dynamics=chess_search_dynamics,
+        runtime_dynamics=chess_dynamics,
+        search_dynamics_override=chess_search_dynamics,
         copy_stack_until_depth=copy_stack_until_depth,
         deep_copy_legal_moves=deep_copy_legal_moves,
     )


### PR DESCRIPTION
### Motivation
- Ensure Chipiron consistently uses the new two-parameter `SearchDynamics[StateT, ActionT]` shape and stops relying on old runtime checks or the `StatelessDynamicsAdapter`. 
- Make the tree-search / runtime `Dynamics` boundary explicit so non-tree selectors keep using runtime `Dynamics` while tree-search receives `SearchDynamics` (with a chess-specific override where needed). 
- Fix a lint/typing nit by raising an exception instance with a stable message when search dynamics are missing.

### Description
- Converted chess search dynamics to the new generic form by changing `ChessSearchDynamics` to inherit `SearchDynamics[ChessState, MoveKey]` and added the marker `__anemone_search_dynamics__ = True` in `src/chipiron/environments/chess/search_dynamics.py`.
- Reworked `make_search_dynamics` to return `SearchDynamics[Any, Any]` and replaced `StatelessDynamicsAdapter` usage with `normalize_search_dynamics(...)` in `src/chipiron/environments/search_dynamics.py`.
- Updated the tree selector factory `create_tree_and_value_move_selector` in `src/chipiron/players/move_selector/factory.py` to accept an optional `search_dynamics_override: SearchDynamics[TurnStateT, Any] | None` and to normalize runtime `dynamics` via `normalize_search_dynamics(...)` when no override is provided.
- Changed recommendation modifiers and composed selectors to accept `SearchDynamics[StateT, Any]` (not runtime `Dynamics`) and updated `AccelerateWhenWinning.modify` to call `step(..., depth=0)` for depth-aware semantics in `src/chipiron/players/move_selector/modifiers.py`.
- Split pipeline-level dynamics into `runtime_dynamics: Dynamics[StateT]` and `search_dynamics_override: SearchDynamics[StateT, Any] | None` in `src/chipiron/players/factory_pipeline.py`, and updated callers accordingly.
- Chess player builder now constructs a concrete `ChessSearchDynamics(...)` and passes it as `search_dynamics_override` while keeping `ChessDynamics()` as `runtime_dynamics` in `src/chipiron/players/factory.py`.
- Replaced the previous class-raise at the tree-search boundary with an instantiation using a class-level `DEFAULT_MESSAGE` on `MissingTreeSearchDynamicsError` for lint/type friendliness in `src/chipiron/players/move_selector/factory.py`.

### Testing
- Ran a repo sweep with `rg` for the patterns `SearchDynamics[...]`, `isinstance(..., SearchDynamics)`, and `StatelessDynamicsAdapter`, and confirmed no remaining offenders after the changes (the lone boundary raise-site was fixed). (succeeded)
- Ran `ruff check` on the touched files and resolved lint warnings; `ruff` completed without errors. (succeeded)
- Ran `pyright src/ | head -200` which executed but reported environment-level missing imports for external dependencies (e.g. `atomheart`, `valanga`, `PySide6`), so full type-checking against third-party stubs could not be completed here. (partial)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699359dc0b1c832ba5c32e2413b2e71b)