### PR TITLE
Remove deprecated player-level search-copy guard

### DIFF
--- a/src/chipiron/data/players/player_config/README.md
+++ b/src/chipiron/data/players/player_config/README.md
@@ -1,1 +1,6 @@
 The files in this directory are supposed to follow the structured defined by the dataclass class 'PlayerArgs' define (recursively) in the file factory.py in chipiron.players (careful, the location might be change in future versions, in that case please update this readme)
+
+Note: chess search-dynamics copy-stack optimization is now configured in
+`implementation_args.search_dynamics_addon` (script-level config), not in player
+`main_move_selector.anemone_args.search.*` blocks.
+

--- a/src/chipiron/environments/search_dynamics.py
+++ b/src/chipiron/environments/search_dynamics.py
@@ -5,7 +5,6 @@ from typing import Any
 from anemone.dynamics import SearchDynamics, normalize_search_dynamics
 from valanga import Dynamics
 
-from chipiron.environments.chess.search_dynamics import ChessSearchDynamics
 from chipiron.environments.types import GameKind
 
 
@@ -13,14 +12,7 @@ def make_search_dynamics(
     *,
     game_kind: GameKind,
     dynamics: Dynamics[Any],
-    copy_stack_until_depth: int = 2,
-    deep_copy_legal_moves: bool = True,
 ) -> SearchDynamics[Any, Any]:
     """Build search dynamics for Anemone from game runtime dynamics."""
-    if game_kind is GameKind.CHESS:
-        return ChessSearchDynamics(
-            copy_stack_until_depth=copy_stack_until_depth,
-            deep_copy_legal_moves=deep_copy_legal_moves,
-        )
-
+    _ = game_kind
     return normalize_search_dynamics(dynamics)

--- a/src/chipiron/environments/search_dynamics_addons.py
+++ b/src/chipiron/environments/search_dynamics_addons.py
@@ -1,0 +1,24 @@
+"""Runtime-configurable addons for search dynamics wrappers."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class SearchDynamicsAddonType(str, Enum):
+    """Supported optional search dynamics wrappers."""
+
+    CHESS_COPY_STACK = "CHESS_COPY_STACK"
+
+
+@dataclass(frozen=True)
+class ChessCopyStackAddonArgs:
+    """Configuration for depth-aware chess board stack copying."""
+
+    type: SearchDynamicsAddonType = SearchDynamicsAddonType.CHESS_COPY_STACK
+    copy_stack_until_depth: int = 2
+    deep_copy_legal_moves: bool = True
+
+
+# Union-style alias for addon args (extend with `| OtherAddonArgs` later).
+SearchDynamicsAddonArgs = ChessCopyStackAddonArgs
+

--- a/src/chipiron/players/factory.py
+++ b/src/chipiron/players/factory.py
@@ -14,7 +14,6 @@ from atomheart.board.utils import FenPlusHistory
 from valanga import Color
 from valanga.policy import BranchSelector
 
-from chipiron.environments.chess.search_dynamics import ChessSearchDynamics
 from chipiron.environments.chess.types import ChessState
 from chipiron.environments.types import GameKind
 from chipiron.players.adapters.chess_adapter import ChessAdapter
@@ -210,16 +209,7 @@ def create_chess_player(
             oracle=policy_oracle_in,
         )
 
-    search_args = getattr(args.main_move_selector, "anemone_args", None)
-    search_config = getattr(search_args, "search", None)
-    copy_stack_until_depth = int(getattr(search_config, "copy_stack_until_depth", 2))
-    deep_copy_legal_moves = bool(getattr(search_config, "deep_copy_legal_moves", True))
-
     chess_dynamics = ChessDynamics()
-    chess_search_dynamics = ChessSearchDynamics(
-        copy_stack_until_depth=copy_stack_until_depth,
-        deep_copy_legal_moves=deep_copy_legal_moves,
-    )
 
     return create_player_with_pipeline(
         name=args.name,
@@ -240,7 +230,7 @@ def create_chess_player(
         ),
         random_generator=random_generator,
         runtime_dynamics=chess_dynamics,
-        search_dynamics_override=chess_search_dynamics,
+        implementation_args=implementation_args,
     )
 
 

--- a/src/chipiron/players/factory_pipeline.py
+++ b/src/chipiron/players/factory_pipeline.py
@@ -20,6 +20,7 @@ from chipiron.players.move_selector.move_selector_args import (
 from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
 from chipiron.players.oracles import PolicyOracle, TerminalOracle, ValueOracle
 from chipiron.players.player import GameAdapter, Player
+from chipiron.scripts.chipiron_args import ImplementationArgs
 from chipiron.players.player_args import HasMoveSelectorType
 
 if TYPE_CHECKING:
@@ -59,6 +60,7 @@ def create_player_with_pipeline(
     random_generator: random.Random,
     runtime_dynamics: Dynamics[StateT],
     search_dynamics_override: SearchDynamics[StateT, Any] | None = None,
+    implementation_args: ImplementationArgs | None = None,
 ) -> Player[SnapT, StateT]:
     """Create a player using a generic selection pipeline with game-specific builders."""
     if isinstance(main_selector_args, TreeAndValueAppArgs):
@@ -76,6 +78,7 @@ def create_player_with_pipeline(
             random_generator=random_generator,
             dynamics=runtime_dynamics,
             search_dynamics_override=search_dynamics_override,
+            implementation_args=implementation_args,
         )
     elif isinstance(main_selector_args, GuiHumanPlayerArgs):
         # Minimal behavior: fail fast with a clear message (or implement GUI path)

--- a/src/chipiron/scripts/base_tree_exploration/inputs/exp_options.yaml
+++ b/src/chipiron/scripts/base_tree_exploration/inputs/exp_options.yaml
@@ -6,3 +6,7 @@ base_script_args:
 implementation_args:
   use_board_modification: True
   use_rust_boards: True
+  search_dynamics_addon:
+    type: CHESS_COPY_STACK
+    copy_stack_until_depth: 2
+    deep_copy_legal_moves: true

--- a/src/chipiron/scripts/chipiron_args.py
+++ b/src/chipiron/scripts/chipiron_args.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from chipiron.environments.search_dynamics_addons import SearchDynamicsAddonArgs
+
 
 @dataclass
 class ImplementationArgs:
@@ -15,3 +17,6 @@ class ImplementationArgs:
     # whether to use the speedup given using the rust version of the chess boards.
     # If True rust is used
     use_rust_boards: bool = False
+
+    # Optional runtime search-dynamics wrapper settings.
+    search_dynamics_addon: SearchDynamicsAddonArgs | None = None

--- a/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/exp_options.yaml
+++ b/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/exp_options.yaml
@@ -30,6 +30,10 @@ base_script_args:
 implementation_args:
   use_board_modification: True
   use_rust_boards: False
+  search_dynamics_addon:
+    type: CHESS_COPY_STACK
+    copy_stack_until_depth: 2
+    deep_copy_legal_moves: true
 
 evaluating_player_args:
   name: RecurZipfBase3

--- a/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/tests/test_exp_options.yaml
+++ b/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/tests/test_exp_options.yaml
@@ -32,6 +32,10 @@ base_script_args:
 implementation_args:
   use_board_modification: True
   use_rust_boards: False
+  search_dynamics_addon:
+    type: CHESS_COPY_STACK
+    copy_stack_until_depth: 2
+    deep_copy_legal_moves: true
 
 evaluating_player_args:
   name: RecurZipfBase3

--- a/src/chipiron/scripts/one_match/inputs/base/exp_options.yaml
+++ b/src/chipiron/scripts/one_match/inputs/base/exp_options.yaml
@@ -13,3 +13,7 @@ base_script_args:
 implementation_args:
   use_board_modification: True
   use_rust_boards: False
+  search_dynamics_addon:
+    type: CHESS_COPY_STACK
+    copy_stack_until_depth: 2
+    deep_copy_legal_moves: true

--- a/src/chipiron/scripts/one_match/inputs/human_play_against_computer/exp_options.yaml
+++ b/src/chipiron/scripts/one_match/inputs/human_play_against_computer/exp_options.yaml
@@ -11,3 +11,7 @@ base_script_args:
 implementation_args:
   use_board_modification: True
   use_rust_boards: True
+  search_dynamics_addon:
+    type: CHESS_COPY_STACK
+    copy_stack_until_depth: 2
+    deep_copy_legal_moves: true

--- a/tests/environments/test_chess_search_dynamics_depth.py
+++ b/tests/environments/test_chess_search_dynamics_depth.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from anemone.dynamics import SearchDynamics
+
+from chipiron.environments.chess.search_dynamics import ChessCopyStackSearchDynamics
+from chipiron.environments.chess.types import ChessState
+
+
+@dataclass
+class FakeBoard:
+    history: list[str] = field(default_factory=list)
+    copy_calls: list[tuple[bool, bool]] = field(default_factory=list)
+    game_over: bool = False
+
+    def copy(self, *, stack: bool, deep_copy_legal_moves: bool) -> "FakeBoard":
+        self.copy_calls.append((stack, deep_copy_legal_moves))
+        history = list(self.history) if stack else []
+        return FakeBoard(
+            history=history,
+            copy_calls=self.copy_calls,
+            game_over=self.game_over,
+        )
+
+    def play_move_key(self, move: str) -> None:
+        self.history.append(move)
+
+    def is_game_over(self) -> bool:
+        return self.game_over
+
+
+# NOTE: wrapper.step() intentionally does not call base.step();
+# this dummy exists only for delegated non-step methods.
+class DummyBaseSearchDynamics(SearchDynamics[ChessState, Any]):
+    __anemone_search_dynamics__ = True
+
+    def legal_actions(self, state: ChessState) -> Any:
+        return ()
+
+    def action_name(self, state: ChessState, action: Any) -> str:
+        return str(action)
+
+    def action_from_name(self, state: ChessState, name: str) -> Any:
+        return name
+
+    def step(self, state: ChessState, action: Any, *, depth: int = 0) -> Any:
+        raise NotImplementedError
+
+
+def _state_with_history(history: list[str]) -> ChessState:
+    return ChessState(FakeBoard(history=history))
+
+
+def test_step_copies_stack_below_threshold() -> None:
+    state = _state_with_history(["e2e4"])
+    dynamics = ChessCopyStackSearchDynamics(
+        base=DummyBaseSearchDynamics(),
+        copy_stack_until_depth=2,
+        deep_copy_legal_moves=True,
+    )
+
+    transition = dynamics.step(state, "e7e5", depth=1)
+
+    assert state.board.copy_calls == [(True, True)]
+    assert transition.next_state.board.history == ["e2e4", "e7e5"]
+
+
+def test_step_does_not_copy_stack_at_or_above_threshold() -> None:
+    state = _state_with_history(["e2e4"])
+    dynamics = ChessCopyStackSearchDynamics(
+        base=DummyBaseSearchDynamics(),
+        copy_stack_until_depth=2,
+        deep_copy_legal_moves=True,
+    )
+
+    transition = dynamics.step(state, "e7e5", depth=2)
+
+    assert state.board.copy_calls == [(False, True)]
+    assert transition.next_state.board.history == ["e7e5"]
+
+
+def test_step_default_depth_copies_stack() -> None:
+    state = _state_with_history(["e2e4"])
+    dynamics = ChessCopyStackSearchDynamics(
+        base=DummyBaseSearchDynamics(),
+        copy_stack_until_depth=2,
+        deep_copy_legal_moves=False,
+    )
+
+    transition = dynamics.step(state, "e7e5")
+
+    assert state.board.copy_calls == [(True, False)]
+    assert transition.next_state.board.history == ["e2e4", "e7e5"]


### PR DESCRIPTION
### Motivation

- Simplify runtime behavior by making the search-copy-stack optimization a single source of truth under `implementation_args.search_dynamics_addon` and avoid runtime failures when legacy player YAML keys remain.
- Follow the clean policy: ignore old player-level keys silently and keep addon application centralized in the move-selector wiring.

### Description

- Removed the deprecated-player-config enforcement from chess player creation by deleting `DeprecatedSearchCopyConfigError` and the check that inspected `main_move_selector.anemone_args.search.copy_stack_until_depth` / `deep_copy_legal_moves` in `src/chipiron/players/factory.py`.
- Preserved the runtime addon path and the chess copy-stack wrapper plumbing (`implementation_args.search_dynamics_addon`, `ChessCopyStackSearchDynamics`, and application in `create_tree_and_value_move_selector`) so the optimization remains configurable at the script level.
- Kept `ImplementationArgs.search_dynamics_addon` and the new `search_dynamics_addons.py` helper type, and ensured `implementation_args` is threaded through the player construction pipeline to the move-selector factory.
- Updated script YAMLs to include the `implementation_args.search_dynamics_addon` block for relevant entrypoints and left unit tests for the copy-stack wrapper in place.

### Testing

- Ran `python -m compileall -q src/chipiron/players/factory.py` to validate syntax; the check succeeded.
- Searched player configs for legacy keys with `rg "copy_stack_until_depth|deep_copy_legal_moves" -n src/chipiron/data/players --glob '*.yaml'` to confirm no in-repo player YAML still relied on the old keys; the search returned no matches.
- Note: unit tests for the chess copy-stack wrapper were added to `tests/environments/test_chess_search_dynamics_depth.py` but were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f02f1010832bb2f8692f671d9e79)