### PR TITLE
Restore discriminated starting positions and add checkers starting args

### DIFF
--- a/src/chipiron/displays/checkers_svg_adapter.py
+++ b/src/chipiron/displays/checkers_svg_adapter.py
@@ -1,8 +1,10 @@
-"""Checkers SVG adapter stub for generic GUI extensibility."""
+"""Checkers SVG adapter for the generic GUI."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import re
 from typing import Any
 
+from chipiron.displays.svg_adapter_errors import InvalidSvgAdapterPayloadTypeError
 from chipiron.displays.svg_adapter_protocol import (
     ClickResult,
     RenderResult,
@@ -10,40 +12,144 @@ from chipiron.displays.svg_adapter_protocol import (
     SvgPosition,
 )
 
+MOVE_SQUARE_RE = re.compile(r"\d+")
+
+
+def _sq32_to_rc(square: int) -> tuple[int, int]:
+    row = (square - 1) // 4
+    offset = (square - 1) % 4
+    col = 1 + 2 * offset if row % 2 == 0 else 2 * offset
+    return row, col
+
+
+def _click_to_sq32(*, x: int, y: int, board_size: int, margin: int) -> int | None:
+    square_size = (board_size - 2 * margin) / 8.0
+    file_ = int((x - margin) / square_size)
+    row_from_top = int((y - margin) / square_size)
+
+    if file_ < 0 or file_ > 7 or row_from_top < 0 or row_from_top > 7:
+        return None
+    if (row_from_top + file_) % 2 == 0:
+        return None
+
+    base = row_from_top * 4
+    if row_from_top % 2 == 0:
+        offset = (file_ - 1) // 2
+    else:
+        offset = file_ // 2
+    if offset < 0 or offset > 3:
+        return None
+    return base + offset + 1
+
+
+def _extract_path(move_name: str) -> list[int]:
+    return [int(chunk) for chunk in MOVE_SQUARE_RE.findall(move_name)]
+
 
 @dataclass
 class CheckersSvgAdapter(SvgGameAdapter):
-    """Minimal checkers adapter placeholder."""
+    """SVG adapter implementation for checkers."""
 
     game_name: str = "checkers"
     board_side: int = 8
 
-    _selected: tuple[int, int] | None = None
+    _selected_square: int | None = None
+    _legal_moves: list[str] = field(default_factory=list)
+    _position_text: str = ""
+    _pieces: list[int] = field(default_factory=lambda: [0] * 32)
 
     def position_from_update(
         self, *, state_tag: object, adapter_payload: Any
     ) -> SvgPosition:
-        """Return an opaque checkers position."""
+        """Build checkers position from incoming generic adapter payload."""
+        if not isinstance(adapter_payload, dict):
+            raise InvalidSvgAdapterPayloadTypeError(
+                adapter_name=self.__class__.__name__,
+                expected_type=dict,
+                actual_value=adapter_payload,
+            )
+
+        position_text = adapter_payload.get("position_text")
+        legal_moves = adapter_payload.get("legal_moves")
+        pieces = adapter_payload.get("pieces")
+
+        valid_pieces = (
+            isinstance(pieces, list)
+            and len(pieces) == 32
+            and all(isinstance(piece, int) for piece in pieces)
+        )
+
+        if (
+            not isinstance(position_text, str)
+            or not isinstance(legal_moves, list)
+            or not all(isinstance(move, str) for move in legal_moves)
+            or not valid_pieces
+        ):
+            raise InvalidSvgAdapterPayloadTypeError(
+                adapter_name=self.__class__.__name__,
+                expected_type=dict,
+                actual_value=adapter_payload,
+            )
+
+        self._position_text = position_text
+        self._legal_moves = legal_moves
+        self._pieces = pieces
+        self.reset_interaction()
         return SvgPosition(state_tag=state_tag, payload=adapter_payload)
 
     def render_svg(self, pos: SvgPosition, size: int) -> RenderResult:
-        """Render a basic checkerboard SVG without pieces."""
+        """Render checkerboard SVG and pieces from structured payload."""
         del pos
         square_size = size / 8
+
         parts = [
             f'<svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}">'
         ]
-        for rank in range(8):
-            for file in range(8):
-                fill = "#777" if (rank + file) % 2 else "#eee"
+
+        for row in range(8):
+            for col in range(8):
+                fill = "#6b4f33" if (row + col) % 2 else "#f2dfc2"
                 parts.append(
-                    f'<rect x="{file * square_size}" y="{rank * square_size}" '
+                    f'<rect x="{col * square_size}" y="{row * square_size}" '
                     f'width="{square_size}" height="{square_size}" fill="{fill}"/>'
                 )
+
+        for index, piece in enumerate(self._pieces):
+            if piece == 0:
+                continue
+            row, col = _sq32_to_rc(index + 1)
+            cx = (col + 0.5) * square_size
+            cy = (row + 0.5) * square_size
+            if piece > 0:
+                fill = "#f7f7f7"
+                stroke = "#202020"
+            else:
+                fill = "#202020"
+                stroke = "#f7f7f7"
+            parts.append(
+                f'<circle cx="{cx}" cy="{cy}" r="{square_size * 0.35}" '
+                f'fill="{fill}" stroke="{stroke}" stroke-width="2"/>'
+            )
+            if abs(piece) == 2:
+                parts.append(
+                    f'<text x="{cx}" y="{cy + square_size * 0.08}" '
+                    'text-anchor="middle" font-size="18" fill="#d4af37">K</text>'
+                )
+
         parts.append("</svg>")
+
+        chunks = [
+            str(self._legal_moves[index : index + 5])
+            for index in range(0, len(self._legal_moves), 5)
+        ]
+
         return RenderResult(
             svg_bytes="".join(parts).encode("utf-8"),
-            info={"round": "-", "fen": "-", "legal_moves": ""},
+            info={
+                "round": "-",
+                "fen": self._position_text,
+                "legal_moves": "\n".join(f"    {chunk}" for chunk in chunks),
+            },
         )
 
     def handle_click(
@@ -55,15 +161,30 @@ class CheckersSvgAdapter(SvgGameAdapter):
         board_size: int,
         margin: int,
     ) -> ClickResult:
-        """Handle click interactions (stub: no action produced yet)."""
+        """Convert click coordinates into a checkers action name."""
         del pos
-        square_size = (board_size - 2 * margin) / 8.0
-        file = int((x - margin) / square_size)
-        rank = 7 - int((y - margin) / square_size)
-        if (rank + file) % 2 == 0:
+        square = _click_to_sq32(x=x, y=y, board_size=board_size, margin=margin)
+        if square is None:
             return ClickResult(action_name=None, interaction_continues=False)
-        return ClickResult(action_name=None, interaction_continues=True)
+
+        if self._selected_square is None:
+            self._selected_square = square
+            return ClickResult(action_name=None, interaction_continues=True)
+
+        matching = [
+            move
+            for move in self._legal_moves
+            if (path := _extract_path(move))
+            and path[0] == self._selected_square
+            and path[-1] == square
+        ]
+        self._selected_square = None
+
+        if len(matching) == 1:
+            return ClickResult(action_name=matching[0], interaction_continues=False)
+
+        return ClickResult(action_name=None, interaction_continues=False)
 
     def reset_interaction(self) -> None:
         """Reset click state for checkers interactions."""
-        self._selected = None
+        self._selected_square = None

--- a/src/chipiron/environments/checkers/__init__.py
+++ b/src/chipiron/environments/checkers/__init__.py
@@ -1,0 +1,6 @@
+"""Checkers environment package."""
+
+from chipiron.environments.checkers.environment import make_checkers_environment
+from chipiron.environments.checkers.tags import CheckersStartTag
+
+__all__ = ["CheckersStartTag", "make_checkers_environment"]

--- a/src/chipiron/environments/checkers/checkers_gui_encoder.py
+++ b/src/chipiron/environments/checkers/checkers_gui_encoder.py
@@ -1,0 +1,52 @@
+"""Checkers GUI encoder."""
+
+from dataclasses import dataclass
+
+from atomheart.games.checkers.generation import generate_legal_moves
+from valanga.game import Seed
+
+from chipiron.displays.gui_protocol import UpdatePayload, UpdGameStatus, UpdStateGeneric
+from chipiron.environments.checkers.types import (
+    CheckersRules,
+    CheckersState,
+    checkers_move_name,
+)
+from chipiron.environments.types import GameKind
+from chipiron.games.game.game_playing_status import PlayingStatus
+from chipiron.utils.communication.gui_encoder import GuiEncoder
+
+
+@dataclass(frozen=True, slots=True)
+class CheckersGuiEncoder(GuiEncoder[CheckersState]):
+    """Encode checkers state updates for the generic GUI."""
+
+    rules: CheckersRules
+    game_kind: GameKind = GameKind.CHECKERS
+
+    def make_state_payload(
+        self,
+        *,
+        state: CheckersState,
+        seed: Seed | None,
+    ) -> UpdatePayload:
+        """Create state payload."""
+        legal_moves = generate_legal_moves(state, self.rules)
+
+        return UpdStateGeneric(
+            state_tag=state.tag,
+            action_name_history=[],
+            adapter_payload={
+                "position_text": state.to_text(),
+                "pieces": state.pieces_by_square(),
+                "legal_moves": [checkers_move_name(move) for move in legal_moves],
+            },
+            seed=seed,
+        )
+
+    def make_status_payload(
+        self,
+        *,
+        status: PlayingStatus,
+    ) -> UpdatePayload:
+        """Create status payload."""
+        return UpdGameStatus(status=status)

--- a/src/chipiron/environments/checkers/environment.py
+++ b/src/chipiron/environments/checkers/environment.py
@@ -1,0 +1,74 @@
+"""Checkers environment wiring."""
+
+from typing import TYPE_CHECKING
+
+from valanga import StateTag
+
+from chipiron.environments.base import Environment
+from chipiron.environments.checkers.checkers_gui_encoder import CheckersGuiEncoder
+from chipiron.environments.checkers.tags import CheckersStartTag
+from chipiron.environments.checkers.types import CheckersDynamics, CheckersRules, CheckersState
+from chipiron.environments.deps import CheckersEnvironmentDeps
+from chipiron.environments.types import GameKind
+from chipiron.players.communications.player_request_encoder import (
+    CheckersPlayerRequestEncoder,
+)
+from chipiron.players.factory_higher_level import create_player_observer_factory
+from chipiron.scripts.chipiron_args import ImplementationArgs
+
+if TYPE_CHECKING:
+    from chipiron.players.factory_higher_level import PlayerObserverFactory
+
+
+class CheckersEnvironmentError(TypeError):
+    """Base error for checkers environment configuration issues."""
+
+
+class CheckersStartTagTypeError(CheckersEnvironmentError):
+    """Raised when an invalid start tag is provided."""
+
+    def __init__(self, tag: StateTag) -> None:
+        """Initialize the error with the invalid tag."""
+        super().__init__(
+            f"Checkers environment expects CheckersStartTag, got {type(tag)!r}"
+        )
+
+
+def make_checkers_environment(
+    *, deps: CheckersEnvironmentDeps
+) -> Environment[CheckersState, str, CheckersStartTag]:
+    """Create checkers environment."""
+
+    def build_player_observer_factory(
+        *,
+        each_player_has_its_own_thread: bool,
+        implementation_args: ImplementationArgs,
+        universal_behavior: bool,
+    ) -> "PlayerObserverFactory":
+        return create_player_observer_factory(
+            game_kind=GameKind.CHECKERS,
+            each_player_has_its_own_thread=each_player_has_its_own_thread,
+            implementation_args=implementation_args,
+            universal_behavior=universal_behavior,
+        )
+
+    def normalize_start_tag(tag: StateTag) -> CheckersStartTag:
+        if not isinstance(tag, CheckersStartTag):
+            raise CheckersStartTagTypeError(tag)
+        return tag
+
+    def make_initial_state(tag: CheckersStartTag) -> CheckersState:
+        return CheckersState.from_text(tag.text)
+
+    rules = CheckersRules(forced_capture=deps.forced_capture)
+
+    return Environment(
+        game_kind=GameKind.CHECKERS,
+        rules=rules,
+        dynamics=CheckersDynamics(rules),
+        gui_encoder=CheckersGuiEncoder(rules=rules),
+        player_encoder=CheckersPlayerRequestEncoder(),
+        make_player_observer_factory=build_player_observer_factory,
+        normalize_start_tag=normalize_start_tag,
+        make_initial_state=make_initial_state,
+    )

--- a/src/chipiron/environments/checkers/starting_position_args.py
+++ b/src/chipiron/environments/checkers/starting_position_args.py
@@ -1,0 +1,45 @@
+"""Checkers starting position args."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal
+
+from valanga import StateTag
+
+from chipiron.environments.checkers.tags import CheckersStartTag
+from chipiron.environments.checkers.types import CheckersState
+from chipiron.environments.starting_position import StartingPositionArgs
+
+
+class CheckersStartingPositionArgsType(StrEnum):
+    """Kinds of checkers starting-position args."""
+
+    STANDARD = "checkers_standard"
+    TEXT = "checkers_text"
+
+
+@dataclass(frozen=True)
+class CheckersStandardStartingPositionArgs(StartingPositionArgs):
+    """Build the canonical standard checkers starting position."""
+
+    type: Literal[CheckersStartingPositionArgsType.STANDARD] = (
+        CheckersStartingPositionArgsType.STANDARD
+    )
+
+    def get_start_tag(self) -> StateTag:
+        """Return standard checkers start tag."""
+        return CheckersStartTag(text=CheckersState.standard().to_text())
+
+
+@dataclass(frozen=True)
+class CheckersTextStartingPositionArgs(StartingPositionArgs):
+    """Build a checkers starting position from serialized text."""
+
+    type: Literal[CheckersStartingPositionArgsType.TEXT] = (
+        CheckersStartingPositionArgsType.TEXT
+    )
+    text: str = ""
+
+    def get_start_tag(self) -> StateTag:
+        """Return explicit checkers start tag."""
+        return CheckersStartTag(text=self.text)

--- a/src/chipiron/environments/checkers/tags.py
+++ b/src/chipiron/environments/checkers/tags.py
@@ -1,0 +1,10 @@
+"""Checkers start-tag representations."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CheckersStartTag:
+    """Lossless serialized checkers start position."""
+
+    text: str

--- a/src/chipiron/environments/checkers/types.py
+++ b/src/chipiron/environments/checkers/types.py
@@ -1,0 +1,13 @@
+"""Checkers-specific type aliases backed by atomheart."""
+
+from atomheart.games.checkers import CheckersDynamics, CheckersRules, CheckersState
+from atomheart.games.checkers.move import MoveKey as CheckersMoveKey
+from atomheart.games.checkers.move import move_name as checkers_move_name
+
+__all__ = [
+    "CheckersState",
+    "CheckersRules",
+    "CheckersDynamics",
+    "CheckersMoveKey",
+    "checkers_move_name",
+]

--- a/src/chipiron/environments/chess/starting_position_args.py
+++ b/src/chipiron/environments/chess/starting_position_args.py
@@ -9,6 +9,10 @@ from typing import Literal
 from valanga import StateTag
 
 from chipiron.environments.chess.tags import ChessStartTag
+from chipiron.environments.checkers.starting_position_args import (
+    CheckersStandardStartingPositionArgs,
+    CheckersTextStartingPositionArgs,
+)
 from chipiron.environments.starting_position import StartingPositionArgs
 
 
@@ -102,7 +106,12 @@ class FileStartingPositionArgs(StartingPositionArgs):
         return ChessStartTag(fen=fen)
 
 
-AllStartingPositionArgs = FenStartingPositionArgs | FileStartingPositionArgs
+AllStartingPositionArgs = (
+    FenStartingPositionArgs
+    | FileStartingPositionArgs
+    | CheckersStandardStartingPositionArgs
+    | CheckersTextStartingPositionArgs
+)
 
 
 def _load_fen_from_file(file_name: str) -> str:

--- a/src/chipiron/environments/deps.py
+++ b/src/chipiron/environments/deps.py
@@ -30,5 +30,7 @@ class ChessEnvironmentDeps:
 class CheckersEnvironmentDeps:
     """Dependencies required to build checkers environments."""
 
+    forced_capture: bool = True
+
 
 EnvDeps = ChessEnvironmentDeps | CheckersEnvironmentDeps

--- a/src/chipiron/environments/environment.py
+++ b/src/chipiron/environments/environment.py
@@ -5,6 +5,9 @@ from typing import Any, Literal, overload
 from atomheart.board.utils import FenPlusHistory
 
 from chipiron.environments.base import Environment
+from chipiron.environments.checkers.environment import make_checkers_environment
+from chipiron.environments.checkers.tags import CheckersStartTag
+from chipiron.environments.checkers.types import CheckersState
 from chipiron.environments.chess.environment import make_chess_environment
 from chipiron.environments.chess.tags import ChessStartTag
 from chipiron.environments.chess.types import ChessState
@@ -38,7 +41,7 @@ def make_environment(
     *,
     game_kind: Literal[GameKind.CHECKERS],
     deps: CheckersEnvironmentDeps,
-) -> Environment[object, object, object]: ...
+) -> Environment[CheckersState, str, CheckersStartTag]: ...
 @overload
 def make_environment(
     *,
@@ -57,6 +60,6 @@ def make_environment(
             return make_chess_environment(deps=deps)
         case GameKind.CHECKERS:
             assert isinstance(deps, CheckersEnvironmentDeps)
-            raise NotImplementedError("Environment for CHECKERS is not implemented yet")
+            return make_checkers_environment(deps=deps)
         case _:
             raise EnvironmentNotFoundError(game_kind)

--- a/src/chipiron/scripts/gui_launcher/builders.py
+++ b/src/chipiron/scripts/gui_launcher/builders.py
@@ -10,6 +10,9 @@ from anemone.progress_monitor.progress_monitor import (
 from parsley import make_partial_dataclass_with_optional_paths
 
 from chipiron import scripts
+from chipiron.environments.checkers.starting_position_args import (
+    CheckersStandardStartingPositionArgs,
+)
 from chipiron.environments.chess.starting_position_args import (
     FenStartingPositionArgs,
     StartingPositionArgsType,
@@ -105,9 +108,9 @@ def generate_inputs(
                     ),
                 )
             else:
-                # Checkers domain is not yet wired end-to-end, but game kind is recorded.
                 game_args = partial_op_game_args(
-                    game_kind=args_chosen_by_user.game_kind
+                    game_kind=args_chosen_by_user.game_kind,
+                    starting_position=CheckersStandardStartingPositionArgs(),
                 )
 
             gui_args = partial_op_match_script_args(

--- a/src/chipiron/utils/communication/gui_encoder_factory.py
+++ b/src/chipiron/utils/communication/gui_encoder_factory.py
@@ -25,5 +25,7 @@ def make_gui_encoder[StateT](
     match game_kind:
         case GameKind.CHESS:
             return cast("GuiEncoder[StateT]", ChessGuiEncoder())
+        case GameKind.CHECKERS:
+            raise GuiEncoderError(game_kind)
         case _:
             raise GuiEncoderError(game_kind)


### PR DESCRIPTION
### Motivation
- Revert the earlier change that made `GameArgs.starting_position` optional because it broke discriminated-union deserialization (dacite-style) and removed the automatic concrete dataclass inference for starting positions. 
- Provide first-class starting-position types for checkers so configuration parsing can produce concrete dataclass instances for both chess and checkers. 
- Keep checkers GUI encoder construction environment-owned because it needs `rules` at construction time and must not be created by the generic factory. 

### Description
- Restored `GameArgs.starting_position` to the concrete union type `AllStartingPositionArgs` instead of `StartingPositionArgs | None`. (`src/chipiron/games/game/game_args.py`).
- Added checkers-specific starting-position dataclasses and enum in `src/chipiron/environments/checkers/starting_position_args.py` and extended `AllStartingPositionArgs` to include `CheckersStandardStartingPositionArgs` and `CheckersTextStartingPositionArgs` (updated `src/chipiron/environments/chess/starting_position_args.py`).
- Implemented checkers environment wiring and encoders: created `checkers` package with `environment.py`, `checkers_gui_encoder.py`, `tags.py`, and `types.py`, and made `make_environment` return a checkers environment for `GameKind.CHECKERS` (`src/chipiron/environments/*`).
- Added a `CheckersPlayerRequestEncoder` and returned it from `make_player_request_encoder` for the `CHECKERS` case (`src/chipiron/players/communications/player_request_encoder.py`).
- Improved the checkers SVG adapter implementation (`src/chipiron/displays/checkers_svg_adapter.py`) to accept structured adapter payloads, render pieces, and translate click coordinates into checkers moves.
- Left the generic GUI encoder factory unable to instantiate a checkers encoder (it now raises `GuiEncoderError` for `GameKind.CHECKERS`) so the environment supplies a properly constructed `CheckersGuiEncoder` (`src/chipiron/utils/communication/gui_encoder_factory.py`).
- Updated `EnvDeps` to include `CheckersEnvironmentDeps` and added a `forced_capture` option, and updated the GUI launcher builder to supply a `CheckersStandardStartingPositionArgs` when the user selects checkers (`src/chipiron/environments/deps.py`, `src/chipiron/scripts/gui_launcher/builders.py`).

### Testing
- Compiled the modified modules with `python -m compileall -q` (targeting the changed files) and the compile step succeeded. 
- Ran `git diff --check` to ensure no trivial whitespace/diff problems and it passed. 
- Performed local code inspections (file additions/edits) to verify the new checkers starting-position types are included in `AllStartingPositionArgs` and that `GameManagerFactory` now calls `starting_position.get_start_tag()` directly without `None` fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6211e318832baaa293bd5d81c66b)