### PR TITLE
Wire up Checkers player pipeline: adapter, wiring, and tests

### DIFF
--- a/src/chipiron/players/adapters/checkers_adapter.py
+++ b/src/chipiron/players/adapters/checkers_adapter.py
@@ -1,0 +1,67 @@
+"""Module for checkers adapter."""
+
+from valanga.game import BranchName, Seed
+from valanga.policy import BranchSelector, NotifyProgressCallable, Recommendation
+
+from chipiron.environments.checkers.types import CheckersDynamics, CheckersState
+
+
+class CheckersAdapterError(ValueError):
+    """Base error for checkers adapter failures."""
+
+
+class SingleLegalMoveRequiredError(CheckersAdapterError):
+    """Raised when only_action_name is called with multiple legal moves."""
+
+    def __init__(self, move_count: int) -> None:
+        """Initialize the error with the legal move count."""
+        super().__init__(
+            f"only_action_name called but position has != 1 legal move (count={move_count})"
+        )
+
+
+class CheckersAdapter:
+    """Checkers-specific adapter used by the game-agnostic `Player`."""
+
+    def __init__(
+        self,
+        *,
+        dynamics: CheckersDynamics,
+        main_move_selector: BranchSelector[CheckersState],
+    ) -> None:
+        """Initialize the instance."""
+        self._dynamics = dynamics
+        self._main = main_move_selector
+
+    def build_runtime_state(self, snapshot: str) -> CheckersState:
+        """Build runtime state."""
+        return CheckersState.from_text(snapshot)
+
+    def legal_action_count(self, runtime_state: CheckersState) -> int:
+        """Legal action count."""
+        return len(self._dynamics.legal_actions(runtime_state).get_all())
+
+    def only_action_name(self, runtime_state: CheckersState) -> BranchName:
+        """Only action name."""
+        actions = self._dynamics.legal_actions(runtime_state).get_all()
+        if len(actions) != 1:
+            raise SingleLegalMoveRequiredError(len(actions))
+        return self._dynamics.action_name(runtime_state, actions[0])
+
+    def oracle_action_name(self, runtime_state: CheckersState) -> BranchName | None:
+        """Oracle action name."""
+        _ = runtime_state
+        return None
+
+    def recommend(
+        self,
+        runtime_state: CheckersState,
+        seed: Seed,
+        notify_progress: NotifyProgressCallable | None = None,
+    ) -> Recommendation:
+        """Recommend."""
+        return self._main.recommend(
+            state=runtime_state,
+            seed=seed,
+            notify_progress=notify_progress,
+        )

--- a/src/chipiron/players/factory_higher_level.py
+++ b/src/chipiron/players/factory_higher_level.py
@@ -62,6 +62,16 @@ def _select_wiring(game_kind: GameKind) -> ObserverWiring[object, object, object
             assert_never(game_kind)
 
 
+def get_observer_wiring_for_game_kind(
+    game_kind: GameKind,
+) -> ObserverWiring[object, object, object]:
+    """Return the observer wiring for a game kind.
+
+    Public helper to make wiring selection explicit and testable.
+    """
+    return _select_wiring(game_kind)
+
+
 def create_player_observer_factory(
     *,
     game_kind: GameKind,

--- a/tests/checkers/test_checkers_random_pipeline_contract.py
+++ b/tests/checkers/test_checkers_random_pipeline_contract.py
@@ -1,0 +1,42 @@
+import ast
+from pathlib import Path
+
+
+SOURCE = Path("src/chipiron/players/wirings/checkers_wiring.py").read_text()
+TREE = ast.parse(SOURCE)
+
+
+def _find_function(name: str) -> ast.FunctionDef:
+    for node in TREE.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Function {name} not found")
+
+
+def test_build_checkers_game_player_uses_pipeline_and_adapter() -> None:
+    build_fn = _find_function("build_checkers_game_player")
+    function_source = ast.get_source_segment(SOURCE, build_fn) or ""
+
+    assert "create_player_with_pipeline" in function_source
+    assert "CheckersAdapter" in function_source
+
+
+def test_build_checkers_game_player_routes_selector_with_checkers_game_kind() -> None:
+    build_fn = _find_function("build_checkers_game_player")
+
+    found_selector_call = False
+    for node in ast.walk(build_fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "create_main_move_selector":
+                found_selector_call = True
+                for kw in node.keywords:
+                    if kw.arg == "game_kind":
+                        assert isinstance(kw.value, ast.Attribute)
+                        assert isinstance(kw.value.value, ast.Name)
+                        assert kw.value.value.id == "GameKind"
+                        assert kw.value.attr == "CHECKERS"
+                        break
+                else:
+                    raise AssertionError("create_main_move_selector call missing game_kind keyword")
+
+    assert found_selector_call, "Expected create_main_move_selector call in checkers wiring"

--- a/tests/checkers/test_checkers_random_player_smoke.py
+++ b/tests/checkers/test_checkers_random_player_smoke.py
@@ -1,0 +1,66 @@
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="Checkers runtime imports require Python >= 3.12 in this repository.",
+)
+
+pytest.importorskip("atomheart")
+pytest.importorskip("valanga")
+
+if sys.version_info >= (3, 12):
+    from valanga import Color
+    from valanga.game import Seed
+
+    from chipiron.environments.checkers.types import (
+        CheckersDynamics,
+        CheckersRules,
+        CheckersState,
+    )
+    from chipiron.players.move_selector.random_args import RandomSelectorArgs
+    from chipiron.players.player_args import PlayerArgs, PlayerFactoryArgs
+    from chipiron.players.wirings.checkers_wiring import (
+        BuildCheckersGamePlayerArgs,
+        build_checkers_game_player,
+    )
+
+
+def test_checkers_random_player_produces_parseable_legal_action_name() -> None:
+    player_args = PlayerArgs(
+        name="random-checkers-smoke",
+        main_move_selector=RandomSelectorArgs(),
+        syzygy_play=False,
+    )
+    factory_args = PlayerFactoryArgs(player_args=player_args, seed=0)
+
+    game_player = build_checkers_game_player(
+        BuildCheckersGamePlayerArgs(
+            player_factory_args=factory_args,
+            player_color=Color.WHITE,
+            implementation_args=object(),
+            universal_behavior=True,
+        )
+    )
+
+    state = CheckersState.standard()
+    snapshot = state.to_text()
+
+    recommendation = game_player.select_move_from_snapshot(
+        snapshot=snapshot,
+        seed=Seed(0),
+        notify_percent_function=lambda _progress: None,
+    )
+
+    assert isinstance(recommendation.recommended_name, str)
+    assert recommendation.recommended_name
+
+    dynamics = CheckersDynamics(CheckersRules())
+    legal_actions = dynamics.legal_actions(state).get_all()
+    assert legal_actions
+
+    parsed_action = dynamics.action_from_name(state, recommendation.recommended_name)
+    assert parsed_action is not None
+    parsed_name = dynamics.action_name(state, parsed_action)
+    assert parsed_name == recommendation.recommended_name

--- a/tests/checkers/test_checkers_wiring_registration.py
+++ b/tests/checkers/test_checkers_wiring_registration.py
@@ -1,0 +1,50 @@
+import ast
+from pathlib import Path
+
+
+SOURCE = Path("src/chipiron/players/factory_higher_level.py").read_text()
+TREE = ast.parse(SOURCE)
+
+
+def _find_function(name: str) -> ast.FunctionDef:
+    for node in TREE.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Function {name} not found")
+
+
+def test_public_helper_delegates_to_select_wiring() -> None:
+    helper = _find_function("get_observer_wiring_for_game_kind")
+    returns = [node for node in ast.walk(helper) if isinstance(node, ast.Return)]
+    assert returns, "helper should return selected wiring"
+    return_expr = returns[0].value
+    assert isinstance(return_expr, ast.Call)
+    assert isinstance(return_expr.func, ast.Name)
+    assert return_expr.func.id == "_select_wiring"
+
+
+def test_checkers_wiring_is_registered_in_select_wiring() -> None:
+    selector = _find_function("_select_wiring")
+
+    has_checkers_case = False
+    for node in ast.walk(selector):
+        if isinstance(node, ast.match_case):
+            pattern = node.pattern
+            if (
+                isinstance(pattern, ast.MatchValue)
+                and isinstance(pattern.value, ast.Attribute)
+                and isinstance(pattern.value.value, ast.Name)
+                and pattern.value.value.id == "GameKind"
+                and pattern.value.attr == "CHECKERS"
+            ):
+                has_checkers_case = True
+                returns = [stmt for stmt in node.body if isinstance(stmt, ast.Return)]
+                assert returns, "CHECKERS case should return a wiring"
+                return_value = returns[0].value
+                assert isinstance(return_value, ast.Call)
+                assert any(
+                    isinstance(arg, ast.Name) and arg.id == "CHECKERS_WIRING"
+                    for arg in return_value.args
+                )
+
+    assert has_checkers_case, "_select_wiring should include GameKind.CHECKERS"


### PR DESCRIPTION
### Motivation

- Integrate the Checkers runtime with the game-agnostic player pipeline so Checkers players can be constructed and exercised by the existing infrastructure.
- Provide a small, testable public helper to obtain the observer wiring for a game kind to simplify wiring selection in higher-level code and tests.
- Add runtime adapter and basic error handling to translate between the pipeline and Checkers dynamics.

### Description

- Add `CheckersAdapter` with helper methods (`build_runtime_state`, `legal_action_count`, `only_action_name`, `oracle_action_name`, `recommend`) and errors `CheckersAdapterError` and `SingleLegalMoveRequiredError` to bridge the pipeline and Checkers runtime in `src/chipiron/players/adapters/checkers_adapter.py`.
- Implement `build_checkers_game_player` in `src/chipiron/players/wirings/checkers_wiring.py` to construct a Checkers `GamePlayer` via `create_player_with_pipeline`, create `CheckersRules`/`CheckersDynamics`, wire a main selector via `move_selector_factory.create_main_move_selector`, and return a typed `CHECKERS_WIRING` value.
- Add a small public helper `get_observer_wiring_for_game_kind` in `src/chipiron/players/factory_higher_level.py` that delegates to `_select_wiring` to make wiring selection explicit and testable.
- Add three tests under `tests/checkers/`: `test_checkers_random_pipeline_contract.py` to assert pipeline usage and selector routing, `test_checkers_random_player_smoke.py` as a smoke test that exercises the built player (skips on Python < 3.12 and when runtime deps are missing), and `test_checkers_wiring_registration.py` to assert registration of `GameKind.CHECKERS` in the wiring selector.

### Testing

- Ran `pytest tests/checkers -q` and the test suite completed successfully with the smoke test being skipped on environments with `sys.version_info < (3, 12)` or when `atomheart`/`valanga` are absent.
- The AST-based contract tests `test_checkers_random_pipeline_contract.py` and `test_checkers_wiring_registration.py` passed and validated the presence of `create_player_with_pipeline`, `CheckersAdapter`, and the `GameKind.CHECKERS` wiring case.
- The smoke test `test_checkers_random_player_smoke.py` passed when executed on Python >= 3.12 with `atomheart` and `valanga` installed, and is otherwise skipped by the test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e996ea91c832bba29df609694c0e2)