### PR TITLE
Add Checkers GUI defaults and Random player option; update launcher UI and tests

### DIFF
--- a/src/chipiron/scripts/gui_launcher/logic.py
+++ b/src/chipiron/scripts/gui_launcher/logic.py
@@ -1,0 +1,20 @@
+"""Game-kind specific defaults for GUI launcher state."""
+
+from chipiron.environments.types import GameKind
+from chipiron.players.player_ids import PlayerConfigTag
+
+from .models import ArgsChosenByUser
+
+
+def apply_game_kind_defaults(args: ArgsChosenByUser) -> None:
+    """Apply game-kind defaults when switching game kind in the launcher."""
+    if args.game_kind is GameKind.CHECKERS:
+        args.player_type_white = PlayerConfigTag.GUI_HUMAN
+        args.strength_white = None
+        args.player_type_black = PlayerConfigTag.GUI_HUMAN
+        args.strength_black = None
+    elif args.game_kind is GameKind.CHESS:
+        args.player_type_white = PlayerConfigTag.RECUR_ZIPF_BASE_3
+        args.strength_white = 1
+        args.player_type_black = PlayerConfigTag.RECUR_ZIPF_BASE_3
+        args.strength_black = 1

--- a/src/chipiron/scripts/gui_launcher/registries.py
+++ b/src/chipiron/scripts/gui_launcher/registries.py
@@ -24,6 +24,7 @@ CHESS_PLAYER_OPTIONS: list[PlayerOption] = [
 
 CHECKERS_PLAYER_OPTIONS: list[PlayerOption] = [
     PlayerOption("Human Player", PlayerConfigTag.GUI_HUMAN, False),
+    PlayerOption("Random", PlayerConfigTag.RANDOM, False),
 ]
 
 

--- a/tests/checkers/test_checkers_gui_launcher.py
+++ b/tests/checkers/test_checkers_gui_launcher.py
@@ -1,0 +1,46 @@
+from chipiron.environments.types import GameKind
+from chipiron.players.player_ids import PlayerConfigTag
+from chipiron.scripts.gui_launcher.logic import apply_game_kind_defaults
+from chipiron.scripts.gui_launcher.models import ArgsChosenByUser
+from chipiron.scripts.gui_launcher.registries import player_options_for_game
+
+
+def test_checkers_registry_includes_random_player_option() -> None:
+    options = player_options_for_game(GameKind.CHECKERS)
+    tags = {opt.tag for opt in options}
+    assert PlayerConfigTag.GUI_HUMAN in tags
+    assert PlayerConfigTag.RANDOM in tags
+
+
+def test_args_defaults_remain_chess_friendly() -> None:
+    args = ArgsChosenByUser()
+    assert args.game_kind is GameKind.CHESS
+    assert args.player_type_white is PlayerConfigTag.RECUR_ZIPF_BASE_3
+    assert args.player_type_black is PlayerConfigTag.RECUR_ZIPF_BASE_3
+    assert args.strength_white == 1
+    assert args.strength_black == 1
+
+
+def test_apply_game_kind_defaults_sets_checkers_human_defaults() -> None:
+    args = ArgsChosenByUser()
+    args.game_kind = GameKind.CHECKERS
+    apply_game_kind_defaults(args)
+    assert args.player_type_white is PlayerConfigTag.GUI_HUMAN
+    assert args.player_type_black is PlayerConfigTag.GUI_HUMAN
+    assert args.strength_white is None
+    assert args.strength_black is None
+
+
+def test_apply_game_kind_defaults_resets_chess_defaults() -> None:
+    args = ArgsChosenByUser(
+        game_kind=GameKind.CHESS,
+        player_type_white=PlayerConfigTag.GUI_HUMAN,
+        strength_white=None,
+        player_type_black=PlayerConfigTag.GUI_HUMAN,
+        strength_black=None,
+    )
+    apply_game_kind_defaults(args)
+    assert args.player_type_white is PlayerConfigTag.RECUR_ZIPF_BASE_3
+    assert args.player_type_black is PlayerConfigTag.RECUR_ZIPF_BASE_3
+    assert args.strength_white == 1
+    assert args.strength_black == 1


### PR DESCRIPTION
### Motivation
- Support Checkers in the GUI launcher by exposing a `Random` player option and ensuring sensible defaults when the user switches game kinds.
- Keep existing Chess defaults intact and ensure UI widgets reflect the chosen game-kind defaults and strength support accurately.

### Description
- Add `apply_game_kind_defaults` in `src/chipiron/scripts/gui_launcher/logic.py` to set per-game default player types and strengths for `GameKind.CHECKERS` and `GameKind.CHESS`.
- Update `src/chipiron/scripts/gui_launcher/registries.py` to include a `Random` `PlayerOption` for `GameKind.CHECKERS` via `PlayerConfigTag.RANDOM`.
- Modify `src/chipiron/scripts/gui_launcher/ui_ctk.py` to call `apply_game_kind_defaults` when the game kind changes, to map tags to labels for menu selection, and to correctly enable/disable and populate strength fields based on the selected player option.
- Add unit tests in `tests/checkers/test_checkers_gui_launcher.py` to validate the registry contains `RANDOM`, the initial chess-friendly defaults, and that `apply_game_kind_defaults` toggles between chess and checkers defaults correctly.

### Testing
- Executed the new test module with `pytest tests/checkers/test_checkers_gui_launcher.py` and all tests passed.
- The tests exercise `player_options_for_game` and `apply_game_kind_defaults` and confirmed expected behavior for both `GameKind.CHECKERS` and `GameKind.CHESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb00a1b0c832ba7a767e1ef0af6c0)