### PR TITLE
Rename syzygy → oracle fields; add checkers Tree piece-count evaluator and configs

### DIFF
--- a/src/chipiron/data/players/player_config/CheckersTreePieceCount.yaml
+++ b/src/chipiron/data/players/player_config/CheckersTreePieceCount.yaml
@@ -1,0 +1,28 @@
+name: CheckersTreePieceCount
+main_move_selector:
+  type: TreeAndValue
+  accelerate_when_winning: True
+  anemone_args:
+    type: TreeAndValue
+    node_selector:
+      type: Composed
+      priority:
+        type: PriorityNoop
+      base:
+        type: RecurZipfBase
+        branch_explorer_priority: priority_best
+    opening_type: all_children
+    recommender_rule:
+      type: almost_equal_logistic
+      temperature: 2
+    stopping_criterion:
+      type: tree_branch_limit
+      tree_branch_limit: 1000
+  evaluator_args:
+    internal_representation_type: '364_bug'  # required by NodeEvaluatorArgs; ignored by checkers wiring
+    master_board_evaluator:
+      oracle_evaluation: False
+      evaluation_scale: stockfish_based  # required by MasterBoardEvaluatorArgs; ignored by checkers wiring
+      board_evaluator:
+        type: basic_evaluation
+oracle_play: False

--- a/src/chipiron/data/players/player_config/Command_Line_Human.yaml
+++ b/src/chipiron/data/players/player_config/Command_Line_Human.yaml
@@ -1,4 +1,4 @@
 name: Command_Line_Human
 main_move_selector:
   type: CommandLineHuman
-syzygy_play: False
+oracle_play: False

--- a/src/chipiron/data/players/player_config/Gui_Human.yaml
+++ b/src/chipiron/data/players/player_config/Gui_Human.yaml
@@ -1,4 +1,4 @@
 name: Gui_Human
 main_move_selector:
   type: GuiHuman
-syzygy_play: False
+oracle_play: False

--- a/src/chipiron/data/players/player_config/Random.yaml
+++ b/src/chipiron/data/players/player_config/Random.yaml
@@ -1,4 +1,4 @@
 name: Random
 main_move_selector:
   type: Random
-syzygy_play: False
+oracle_play: False

--- a/src/chipiron/data/players/player_config/RecurZipfBase3.yaml
+++ b/src/chipiron/data/players/player_config/RecurZipfBase3.yaml
@@ -25,11 +25,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/RecurZipfBase4.yaml
+++ b/src/chipiron/data/players/player_config/RecurZipfBase4.yaml
@@ -21,11 +21,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/RecurZipfSequool.yaml
+++ b/src/chipiron/data/players/player_config/RecurZipfSequool.yaml
@@ -17,13 +17,13 @@ main_move_selector:
   node_evaluator:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_364_no_bug_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True
 
 

--- a/src/chipiron/data/players/player_config/Sequool.yaml
+++ b/src/chipiron/data/players/player_config/Sequool.yaml
@@ -24,13 +24,13 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True
 
 

--- a/src/chipiron/data/players/player_config/SequoolOnlyPromising.yaml
+++ b/src/chipiron/data/players/player_config/SequoolOnlyPromising.yaml
@@ -17,13 +17,13 @@ main_move_selector:
   node_evaluator:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_364_no_bug_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True
 
 

--- a/src/chipiron/data/players/player_config/SequoolOnlyPromisingRecur.yaml
+++ b/src/chipiron/data/players/player_config/SequoolOnlyPromisingRecur.yaml
@@ -17,13 +17,13 @@ main_move_selector:
   node_evaluator:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_364_no_bug_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True
 
 

--- a/src/chipiron/data/players/player_config/Stockfish.yaml
+++ b/src/chipiron/data/players/player_config/Stockfish.yaml
@@ -2,4 +2,4 @@ name: Stockfish
 main_move_selector:
   type: Stockfish
   depth: 10
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/Uniform.yaml
+++ b/src/chipiron/data/players/player_config/Uniform.yaml
@@ -20,11 +20,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/UniformDepth.yaml
+++ b/src/chipiron/data/players/player_config/UniformDepth.yaml
@@ -21,11 +21,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/UniformDepth2.yaml
+++ b/src/chipiron/data/players/player_config/UniformDepth2.yaml
@@ -20,11 +20,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/UniformDepth3.yaml
+++ b/src/chipiron/data/players/player_config/UniformDepth3.yaml
@@ -21,11 +21,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/Uniformbase.yaml
+++ b/src/chipiron/data/players/player_config/Uniformbase.yaml
@@ -14,8 +14,8 @@ main_move_selector:
       tree_branch_limit: 1000
   node_evaluator:
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: entire_real_axis
       board_evaluator:
         type: basic_evaluation
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/data/players/player_config/chipiron/chipiron.yaml
+++ b/src/chipiron/data/players/player_config/chipiron/chipiron.yaml
@@ -28,11 +28,11 @@ main_move_selector:
   evaluator_args:
     internal_representation_type: '364_bug'
     master_board_evaluator:
-      syzygy_evaluation: True
+      oracle_evaluation: True
       evaluation_scale: stockfish_based
       board_evaluator:
         type: neural_network
         neural_nets_model_and_architecture:
           model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
           nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-syzygy_play: True
+oracle_play: True

--- a/src/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/src/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -55,8 +55,8 @@ class UnsupportedBoardEvaluatorArgsError(MasterBoardEvaluatorError):
 class MasterBoardEvaluatorArgs:
     """Represents the arguments for a master board evaluator."""
 
-    # Whether to use syzygy table for evaluation.
-    syzygy_evaluation: bool
+    # Whether to use oracle evaluation when available.
+    oracle_evaluation: bool
 
     # The evaluation scale used by the node evaluator. (Default values when nodes are found to be over)
     evaluation_scale: EvaluationScale
@@ -67,7 +67,7 @@ class MasterBoardEvaluatorArgs:
 class MasterBoardEvaluator:
     """The MasterBoardEvaluator class is responsible for evaluating the value of chess positions (that are IBoard).
 
-    It uses a board evaluator and a syzygy evaluator to calculate the value of the positions.
+    It uses a board evaluator and optional oracle-based evaluation to calculate values.
     """
 
     # The board evaluator used to evaluate the chess board.
@@ -238,7 +238,7 @@ def create_master_state_evaluator_from_args(
         MasterBoardEvaluator: _description_
 
     """
-    if master_board_evaluator.syzygy_evaluation:
+    if master_board_evaluator.oracle_evaluation:
         value_oracle_ = value_oracle
         terminal_oracle_ = terminal_oracle
     else:

--- a/src/chipiron/players/evaluators/__init__.py
+++ b/src/chipiron/players/evaluators/__init__.py
@@ -1,0 +1,2 @@
+"""Game-specific lightweight evaluators."""
+

--- a/src/chipiron/players/evaluators/checkers_piece_count.py
+++ b/src/chipiron/players/evaluators/checkers_piece_count.py
@@ -1,0 +1,87 @@
+"""Simple checkers evaluator wiring for tree search."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from anemone.node_evaluation.node_direct_evaluation.node_direct_evaluator import (
+    MasterStateEvaluator,
+)
+from valanga import Color, State
+from valanga.over_event import HowOver, OverEvent, Winner
+
+from chipiron.environments.checkers.checkers_rules import CheckersRules
+from chipiron.environments.checkers.types import CheckersState
+from chipiron.games.game.game_rules import OutcomeKind
+
+KING_WEIGHT = 2
+
+
+@dataclass(frozen=True)
+class CheckersPieceCountEvaluator:
+    """Material-count evaluator from White's perspective."""
+
+    king_weight: int = KING_WEIGHT
+
+    def value_white(self, state: CheckersState) -> float:
+        """Return material score from White's perspective."""
+        white_men = state.wm.bit_count()
+        white_kings = state.wk.bit_count()
+        black_men = state.bm.bit_count()
+        black_kings = state.bk.bit_count()
+
+        return float(
+            (white_men + self.king_weight * white_kings)
+            - (black_men + self.king_weight * black_kings)
+        )
+
+
+@dataclass(frozen=True)
+class CheckersOverEventDetector:
+    """Detect terminal outcomes using chipiron's checkers rules adapter."""
+
+    rules: CheckersRules
+
+    def check_obvious_over_events(
+        self, state: State
+    ) -> tuple[OverEvent | None, float | None]:
+        """Return terminal over-event + value when available."""
+        checkers_state = cast("CheckersState", state)
+        outcome = self.rules.outcome(state=checkers_state)
+        if outcome is None:
+            return None, None
+
+        if outcome.kind is OutcomeKind.WIN:
+            who_is_winner = (
+                Winner.WHITE if outcome.winner is Color.WHITE else Winner.BLACK
+            )
+            over_event = OverEvent(
+                how_over=HowOver.WIN,
+                who_is_winner=who_is_winner,
+                termination=None,
+            )
+            value_white = 1.0 if outcome.winner is Color.WHITE else -1.0
+            return over_event, value_white
+
+        over_event = OverEvent(
+            how_over=HowOver.DRAW,
+            who_is_winner=Winner.NO_KNOWN_WINNER,
+            termination=None,
+        )
+        return over_event, 0.0
+
+
+@dataclass(frozen=True)
+class CheckersMasterEvaluator(MasterStateEvaluator):
+    """Anemone-compatible master evaluator for checkers."""
+
+    evaluator: CheckersPieceCountEvaluator
+    over: CheckersOverEventDetector
+
+    def value_white(self, state: State) -> float:
+        """Evaluate state from White's perspective."""
+        _over_event, terminal_value_white = self.over.check_obvious_over_events(state)
+        if terminal_value_white is not None:
+            return float(terminal_value_white)
+        return self.evaluator.value_white(cast("CheckersState", state))

--- a/src/chipiron/players/factory.py
+++ b/src/chipiron/players/factory.py
@@ -85,20 +85,26 @@ def create_tag_player(
     Returns: the player
 
     """
-    syzygy_table: AnySyzygyTable | None = create_syzygy(
-        use_rust=implementation_args.use_rust_boards
-    )
-    policy_oracle = (
-        ChessSyzygyPolicyOracle(syzygy_table) if syzygy_table is not None else None
-    )
-    value_oracle = (
-        ChessSyzygyValueOracle(syzygy_table) if syzygy_table is not None else None
-    )
-    terminal_oracle = (
-        ChessSyzygyTerminalOracle(syzygy_table) if syzygy_table is not None else None
-    )
-
     args_player: ChessPlayerArgs = tag.get_players_args()
+
+    policy_oracle = None
+    value_oracle = None
+    terminal_oracle = None
+    if args_player.oracle_play:
+        syzygy_table: AnySyzygyTable | None = create_syzygy(
+            use_rust=implementation_args.use_rust_boards
+        )
+        policy_oracle = (
+            ChessSyzygyPolicyOracle(syzygy_table) if syzygy_table is not None else None
+        )
+        value_oracle = (
+            ChessSyzygyValueOracle(syzygy_table) if syzygy_table is not None else None
+        )
+        terminal_oracle = (
+            ChessSyzygyTerminalOracle(syzygy_table)
+            if syzygy_table is not None
+            else None
+        )
 
     if tree_branch_limit is not None:
         # TODO: find a prettier way to do this
@@ -111,7 +117,9 @@ def create_tag_player(
             TreeBranchLimitArgs,
         )
 
-        args_player.main_move_selector.anemone_args.stopping_criterion.tree_branch_limit = tree_branch_limit
+        args_player.main_move_selector.anemone_args.stopping_criterion.tree_branch_limit = (
+            tree_branch_limit
+        )
 
     return create_chess_player(
         args=args_player,

--- a/src/chipiron/players/move_selector/tree_and_value_args.py
+++ b/src/chipiron/players/move_selector/tree_and_value_args.py
@@ -20,7 +20,7 @@ class NodeEvaluatorArgs:
 
     Attributes:
     - type: The type of the node evaluator.
-    - syzygy_evaluation: A boolean indicating whether syzygy evaluation is enabled.
+    - oracle_evaluation: A boolean indicating whether oracle evaluation is enabled.
     - representation: The representation of the node evaluator.
 
     """

--- a/src/chipiron/players/player_args.py
+++ b/src/chipiron/players/player_args.py
@@ -26,13 +26,13 @@ class PlayerArgs:
     Attributes:
         name (str): The name of the player.
         main_move_selector (AnyMoveSelectorArgs): The main move selector for the player.
-        syzygy_play (bool): Whether to play with syzygy when possible.
+        oracle_play (bool): Whether to use an oracle when available.
 
     """
 
     name: str
     main_move_selector: AnyMoveSelectorArgs
-    syzygy_play: bool
+    oracle_play: bool
 
     def is_human(self) -> bool:
         """Check if the player is a human player.

--- a/src/chipiron/players/player_ids.py
+++ b/src/chipiron/players/player_ids.py
@@ -47,6 +47,7 @@ class PlayerConfigTag(StrEnum):
     UNIFORM = "Uniform"
     RANDOM = "Random"
     STOCKFISH = "Stockfish"
+    CHECKERS_TREE_PIECECOUNT = "CheckersTreePieceCount"
 
     def is_human(self) -> bool:
         """Check if the player is human.

--- a/src/chipiron/players/wirings/checkers_wiring.py
+++ b/src/chipiron/players/wirings/checkers_wiring.py
@@ -2,10 +2,12 @@
 
 import random
 from dataclasses import dataclass
-from typing import Any, NoReturn
 
 from valanga import Color
 
+from chipiron.environments.checkers.checkers_rules import (
+    CheckersRules as CheckersRulesAdapter,
+)
 from chipiron.environments.checkers.types import (
     CheckersDynamics,
     CheckersRules,
@@ -13,10 +15,19 @@ from chipiron.environments.checkers.types import (
 )
 from chipiron.environments.types import GameKind
 from chipiron.players.adapters.checkers_adapter import CheckersAdapter
+from chipiron.players.boardevaluators.master_board_evaluator import (
+    MasterBoardEvaluatorArgs,
+)
+from chipiron.players.evaluators.checkers_piece_count import (
+    CheckersMasterEvaluator,
+    CheckersOverEventDetector,
+    CheckersPieceCountEvaluator,
+)
 from chipiron.players.factory_pipeline import create_player_with_pipeline
 from chipiron.players.game_player import GamePlayer
 from chipiron.players.move_selector import factory as move_selector_factory
 from chipiron.players.observer_wiring import ObserverWiring
+from chipiron.players.oracles import TerminalOracle, ValueOracle
 from chipiron.players.player_args import PlayerFactoryArgs
 
 
@@ -30,8 +41,20 @@ class BuildCheckersGamePlayerArgs:
     universal_behavior: bool
 
 
-def _no_checkers_master_evaluator(*_args: Any, **_kwargs: Any) -> NoReturn:
-    raise NotImplementedError("Tree/value evaluator not implemented for checkers")
+def build_checkers_master_evaluator(
+    evaluator_args: MasterBoardEvaluatorArgs,
+    value_oracle: ValueOracle[CheckersState] | None,
+    terminal_oracle: TerminalOracle[CheckersState] | None,
+    rules_adapter: CheckersRulesAdapter,
+) -> CheckersMasterEvaluator:
+    """Build an anemone-compatible master evaluator for checkers."""
+    del evaluator_args
+    del value_oracle
+    del terminal_oracle
+    return CheckersMasterEvaluator(
+        evaluator=CheckersPieceCountEvaluator(),
+        over=CheckersOverEventDetector(rules=rules_adapter),
+    )
 
 
 def build_checkers_game_player(
@@ -41,10 +64,23 @@ def build_checkers_game_player(
     random_generator = random.Random(args.player_factory_args.seed)
     _ = args.universal_behavior
 
-    rules = CheckersRules()
-    dynamics = CheckersDynamics(rules)
+    atom_rules = CheckersRules()
+    rules_adapter = CheckersRulesAdapter(inner=atom_rules)
+    dynamics = CheckersDynamics(atom_rules)
 
     player_args = args.player_factory_args.player_args
+
+    def master_evaluator_from_args(
+        evaluator_args: MasterBoardEvaluatorArgs,
+        value_oracle: ValueOracle[CheckersState] | None,
+        terminal_oracle: TerminalOracle[CheckersState] | None,
+    ) -> CheckersMasterEvaluator:
+        return build_checkers_master_evaluator(
+            evaluator_args=evaluator_args,
+            value_oracle=value_oracle,
+            terminal_oracle=terminal_oracle,
+            rules_adapter=rules_adapter,
+        )
 
     player = create_player_with_pipeline(
         name=player_args.name,
@@ -53,7 +89,7 @@ def build_checkers_game_player(
         policy_oracle=None,
         value_oracle=None,
         terminal_oracle=None,
-        master_evaluator_from_args=_no_checkers_master_evaluator,
+        master_evaluator_from_args=master_evaluator_from_args,
         adapter_builder=lambda selector, _policy_oracle: CheckersAdapter(
             dynamics=dynamics,
             main_move_selector=selector,

--- a/src/chipiron/players/wirings/chess_wiring.py
+++ b/src/chipiron/players/wirings/chess_wiring.py
@@ -37,13 +37,20 @@ def build_chess_game_player(
     args: BuildChessGamePlayerArgs,
 ) -> GamePlayer[FenPlusHistory, ChessState]:
     """Build chess game player."""
-    create_syzygy = create_syzygy_factory(
-        use_rust=args.implementation_args.use_rust_boards
-    )
-    syzygy = args.syzygy_table if args.syzygy_table is not None else create_syzygy()
-    policy_oracle = ChessSyzygyPolicyOracle(syzygy) if syzygy is not None else None
-    value_oracle = ChessSyzygyValueOracle(syzygy) if syzygy is not None else None
-    terminal_oracle = ChessSyzygyTerminalOracle(syzygy) if syzygy is not None else None
+    policy_oracle = None
+    value_oracle = None
+    terminal_oracle = None
+
+    if args.player_factory_args.player_args.oracle_play:
+        create_syzygy = create_syzygy_factory(
+            use_rust=args.implementation_args.use_rust_boards
+        )
+        syzygy = args.syzygy_table if args.syzygy_table is not None else create_syzygy()
+        policy_oracle = ChessSyzygyPolicyOracle(syzygy) if syzygy is not None else None
+        value_oracle = ChessSyzygyValueOracle(syzygy) if syzygy is not None else None
+        terminal_oracle = (
+            ChessSyzygyTerminalOracle(syzygy) if syzygy is not None else None
+        )
     return create_game_player(
         player_factory_args=args.player_factory_args,
         player_color=args.player_color,

--- a/src/chipiron/scripts/gui_launcher/registries.py
+++ b/src/chipiron/scripts/gui_launcher/registries.py
@@ -25,6 +25,7 @@ CHESS_PLAYER_OPTIONS: list[PlayerOption] = [
 CHECKERS_PLAYER_OPTIONS: list[PlayerOption] = [
     PlayerOption("Human Player", PlayerConfigTag.GUI_HUMAN, False),
     PlayerOption("Random", PlayerConfigTag.RANDOM, False),
+    PlayerOption("Tree (piece count)", PlayerConfigTag.CHECKERS_TREE_PIECECOUNT, False),
 ]
 
 

--- a/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/exp_options.yaml
+++ b/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/exp_options.yaml
@@ -54,14 +54,14 @@ evaluating_player_args:
     evaluator_args:
       internal_representation_type: '364_bug'
       master_board_evaluator:
-        syzygy_evaluation: True
+        oracle_evaluation: True
         evaluation_scale: stockfish_based
         board_evaluator:
           type: neural_network
           neural_nets_model_and_architecture:
             model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
             nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-  syzygy_play: True
+  oracle_play: True
 
 
 epochs_number_with_respect_to_evaluating_player: 10

--- a/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/learn_from_scratch_value_and_fixed_boards.py
+++ b/src/chipiron/scripts/learn_from_scratch_value_and_fixed_boards/learn_from_scratch_value_and_fixed_boards.py
@@ -83,7 +83,7 @@ class LearnNNFromScratchScriptArgs:
         default_factory=lambda: PlayerArgs(
             name="Random",
             main_move_selector=RandomSelectorArgs(),
-            syzygy_play=False,
+            oracle_play=False,
         )
     )
 

--- a/tests/checkers/test_checkers_gui_launcher.py
+++ b/tests/checkers/test_checkers_gui_launcher.py
@@ -10,6 +10,7 @@ def test_checkers_registry_includes_random_player_option() -> None:
     tags = {opt.tag for opt in options}
     assert PlayerConfigTag.GUI_HUMAN in tags
     assert PlayerConfigTag.RANDOM in tags
+    assert PlayerConfigTag.CHECKERS_TREE_PIECECOUNT in tags
 
 
 def test_args_defaults_remain_chess_friendly() -> None:

--- a/tests/checkers/test_checkers_recur_zipf_player_smoke.py
+++ b/tests/checkers/test_checkers_recur_zipf_player_smoke.py
@@ -7,31 +7,34 @@ pytestmark = pytest.mark.skipif(
     reason="Checkers runtime imports require Python >= 3.12 in this repository.",
 )
 
-pytest.importorskip("atomheart")
-pytest.importorskip("valanga")
 
-from valanga import Color
-from valanga.game import Seed
-
-from chipiron.environments.checkers.types import (
-    CheckersDynamics,
-    CheckersRules,
-    CheckersState,
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="Checkers runtime imports require Python >= 3.12 in this repository.",
 )
-from chipiron.players.move_selector.random_args import RandomSelectorArgs
-from chipiron.players.player_args import PlayerArgs, PlayerFactoryArgs
-from chipiron.players.wirings.checkers_wiring import (
-    BuildCheckersGamePlayerArgs,
-    build_checkers_game_player,
-)
+def test_checkers_tree_piececount_player_produces_parseable_legal_action_name() -> None:
+    pytest.importorskip("atomheart")
+    pytest.importorskip("valanga")
+    pytest.importorskip("anemone")
 
+    from valanga import Color
+    from valanga.game import Seed
 
-def test_checkers_random_player_produces_parseable_legal_action_name() -> None:
-    player_args = PlayerArgs(
-        name="random-checkers-smoke",
-        main_move_selector=RandomSelectorArgs(),
-        oracle_play=False,
+    from chipiron.environments.checkers.types import (
+        CheckersDynamics,
+        CheckersRules,
+        CheckersState,
     )
+    from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
+    from chipiron.players.player_args import PlayerFactoryArgs
+    from chipiron.players.player_ids import PlayerConfigTag
+    from chipiron.players.wirings.checkers_wiring import (
+        BuildCheckersGamePlayerArgs,
+        build_checkers_game_player,
+    )
+
+    player_args = PlayerConfigTag.CHECKERS_TREE_PIECECOUNT.get_players_args()
+    assert isinstance(player_args.main_move_selector, TreeAndValueAppArgs)
     factory_args = PlayerFactoryArgs(player_args=player_args, seed=0)
 
     game_player = build_checkers_game_player(

--- a/tests/checkers/test_checkers_tree_piececount_config.py
+++ b/tests/checkers/test_checkers_tree_piececount_config.py
@@ -1,0 +1,23 @@
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="Config loading in this repository targets Python >= 3.12.",
+)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="Config loading in this repository targets Python >= 3.12.",
+)
+def test_checkers_tree_piececount_yaml_loads() -> None:
+    pytest.importorskip("parsley")
+
+    from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
+    from chipiron.players.player_ids import PlayerConfigTag
+
+    args = PlayerConfigTag.CHECKERS_TREE_PIECECOUNT.get_players_args()
+    assert args.name == "CheckersTreePieceCount"
+    assert isinstance(args.main_move_selector, TreeAndValueAppArgs)

--- a/tests/players/test_chess_wiring_oracle_play_contract.py
+++ b/tests/players/test_chess_wiring_oracle_play_contract.py
@@ -1,0 +1,17 @@
+import ast
+from pathlib import Path
+
+SOURCE_PATH = Path("src/chipiron/players/wirings/chess_wiring.py")
+SOURCE = SOURCE_PATH.read_text(encoding="utf-8")
+TREE = ast.parse(SOURCE)
+
+
+def test_build_chess_game_player_checks_oracle_play_flag() -> None:
+    function_node = next(
+        node
+        for node in TREE.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_chess_game_player"
+    )
+
+    function_source = ast.get_source_segment(SOURCE, function_node) or ""
+    assert "args.player_factory_args.player_args.oracle_play" in function_source

--- a/tests/players/test_oracle_field_schema.py
+++ b/tests/players/test_oracle_field_schema.py
@@ -1,0 +1,21 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="Project runtime/parsing checks require Python >= 3.12.",
+)
+def test_chess_player_config_uses_oracle_fields() -> None:
+    pytest.importorskip("parsley")
+
+    from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
+    from chipiron.players.player_ids import PlayerConfigTag
+
+    args = PlayerConfigTag.RECUR_ZIPF_BASE_3.get_players_args()
+    assert args.oracle_play is True
+
+    selector = args.main_move_selector
+    assert isinstance(selector, TreeAndValueAppArgs)
+    assert selector.evaluator_args.master_board_evaluator.oracle_evaluation is True

--- a/tests/players/test_oracle_yaml_schema_guard.py
+++ b/tests/players/test_oracle_yaml_schema_guard.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+PLAYER_CONFIG_ROOT = Path("src/chipiron/data/players/player_config")
+
+
+def test_no_legacy_syzygy_keys_in_player_yaml_configs() -> None:
+    yaml_files = sorted(PLAYER_CONFIG_ROOT.rglob("*.yaml"))
+    assert yaml_files, "Expected player YAML configs to exist"
+
+    for yaml_file in yaml_files:
+        text = yaml_file.read_text(encoding="utf-8")
+        assert "syzygy_play" not in text, f"Legacy key found in {yaml_file}"
+        assert "syzygy_evaluation" not in text, f"Legacy key found in {yaml_file}"

--- a/tests/scripts/learn_from_scratch_value_and_fixed_boards/test_exp_options.yaml
+++ b/tests/scripts/learn_from_scratch_value_and_fixed_boards/test_exp_options.yaml
@@ -56,14 +56,14 @@ evaluating_player_args:
     evaluator_args:
       internal_representation_type: '364_bug'
       master_board_evaluator:
-        syzygy_evaluation: True
+        oracle_evaluation: True
         evaluation_scale: stockfish_based
         board_evaluator:
           type: neural_network
           neural_nets_model_and_architecture:
             model_weights_file_name: "package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/param_multi_layer_perceptron_772_20_1_parametric_relu_hyperbolic_tangent_player_to_move.pt"
             nn_architecture_args_path_to_yaml_file: 'package://data/players/board_evaluators/nn_pytorch/prelu_no_bug/architecture.yaml'
-  syzygy_play: True
+  oracle_play: True
 
 
 epochs_number_with_respect_to_evaluating_player: 10


### PR DESCRIPTION
### Motivation
- Replace legacy "syzygy" naming with a more generic "oracle" terminology across player configs and evaluator args to support non-syzygy oracles and remove legacy keys. 
- Add a lightweight Tree-and-Value player for Checkers that uses a simple material-count evaluator so checkers can use existing tree search plumbing.

### Description
- Renamed fields and docs: `syzygy_play` → `oracle_play` in player config YAML and `PlayerArgs`, and `syzygy_evaluation` → `oracle_evaluation` in `MasterBoardEvaluatorArgs` and related YAMLs. 
- Wiring changes so oracle/syzygy artifacts are only created when `oracle_play` is enabled: updated `create_tag_player` in `players/factory.py`, `build_chess_game_player` in `players/wirings/chess_wiring.py`, and related code paths to check `args.player_factory_args.player_args.oracle_play`. 
- Implemented a simple checkers master evaluator and over-event detector in `players/evaluators/checkers_piece_count.py` and hooked it into checkers wiring via `players/wirings/checkers_wiring.py`, exposing a new player config `CheckersTreePieceCount` (`src/chipiron/data/players/player_config/CheckersTreePieceCount.yaml`) and registering it in the GUI registry. 
- Added module `players/evaluators/__init__.py` and updated `PlayerConfigTag` and GUI registries to include the new checkers player option. 
- Updated many player YAML configs to use `oracle_play` / `oracle_evaluation` instead of the legacy keys and removed occurrences of `syzygy_play` and `syzygy_evaluation`. 
- Added tests to assert the new behavior and guard against legacy keys, including `tests/players/test_oracle_field_schema.py`, `tests/players/test_oracle_yaml_schema_guard.py`, AST-based check `tests/players/test_chess_wiring_oracle_play_contract.py`, and multiple checkers smoke/config tests `tests/checkers/*`.

### Testing
- Ran the automated test suite with `pytest` covering the changed areas and newly added tests, including `tests/players` and `tests/checkers`, and the new YAML guard tests; they passed. 
- Added smoke tests for the new checkers tree player (`tests/checkers/test_checkers_recur_zipf_player_smoke.py`) and a YAML-load test for the checkers config (`tests/checkers/test_checkers_tree_piececount_config.py`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec3e2130c832b905db5409783f39e)