### PR TITLE
Use evaluation-scale enum for checkers terminal values and add evaluator defaults

### DIFF
--- a/src/chipiron/data/players/player_config/CheckersTreePieceCount.yaml
+++ b/src/chipiron/data/players/player_config/CheckersTreePieceCount.yaml
@@ -19,10 +19,10 @@ main_move_selector:
       type: tree_branch_limit
       tree_branch_limit: 1000
   evaluator_args:
-    internal_representation_type: '364_bug'  # required by NodeEvaluatorArgs; ignored by checkers wiring
+    internal_representation_type: "no"
     master_board_evaluator:
       oracle_evaluation: False
-      evaluation_scale: stockfish_based  # required by MasterBoardEvaluatorArgs; ignored by checkers wiring
+      evaluation_scale: "entire_real_axis"
       board_evaluator:
         type: basic_evaluation
 oracle_play: False

--- a/src/chipiron/players/boardevaluators/master_board_evaluator.py
+++ b/src/chipiron/players/boardevaluators/master_board_evaluator.py
@@ -55,13 +55,13 @@ class UnsupportedBoardEvaluatorArgsError(MasterBoardEvaluatorError):
 class MasterBoardEvaluatorArgs:
     """Represents the arguments for a master board evaluator."""
 
+    board_evaluator: AllBoardEvaluatorArgs
+
     # Whether to use oracle evaluation when available.
-    oracle_evaluation: bool
+    oracle_evaluation: bool = False
 
     # The evaluation scale used by the node evaluator. (Default values when nodes are found to be over)
-    evaluation_scale: EvaluationScale
-
-    board_evaluator: AllBoardEvaluatorArgs
+    evaluation_scale: EvaluationScale = EvaluationScale.ENTIRE_REAL_AXIS
 
 
 class MasterBoardEvaluator:

--- a/src/chipiron/players/move_selector/tree_and_value_args.py
+++ b/src/chipiron/players/move_selector/tree_and_value_args.py
@@ -25,11 +25,11 @@ class NodeEvaluatorArgs:
 
     """
 
-    # The internal representation type used by the node evaluator.
-    internal_representation_type: InternalTensorRepresentationType
-
     # The arguments for the master board evaluator.
     master_board_evaluator: master_board_evaluator.MasterBoardEvaluatorArgs
+
+    # The internal representation type used by the node evaluator.
+    internal_representation_type: InternalTensorRepresentationType | None = None
 
 
 @dataclass(frozen=True)

--- a/src/chipiron/players/wirings/checkers_wiring.py
+++ b/src/chipiron/players/wirings/checkers_wiring.py
@@ -15,6 +15,7 @@ from chipiron.environments.checkers.types import (
 )
 from chipiron.environments.types import GameKind
 from chipiron.players.adapters.checkers_adapter import CheckersAdapter
+from chipiron.players.boardevaluators.evaluation_scale import get_value_over_enum
 from chipiron.players.boardevaluators.master_board_evaluator import (
     MasterBoardEvaluatorArgs,
 )
@@ -48,12 +49,14 @@ def build_checkers_master_evaluator(
     rules_adapter: CheckersRulesAdapter,
 ) -> CheckersMasterEvaluator:
     """Build an anemone-compatible master evaluator for checkers."""
-    del evaluator_args
     del value_oracle
     del terminal_oracle
+    value_over_enum = get_value_over_enum(evaluator_args.evaluation_scale)
     return CheckersMasterEvaluator(
         evaluator=CheckersPieceCountEvaluator(),
-        over=CheckersOverEventDetector(rules=rules_adapter),
+        over=CheckersOverEventDetector(
+            rules=rules_adapter, value_over_enum=value_over_enum
+        ),
     )
 
 

--- a/tests/checkers/test_checkers_terminal_scale.py
+++ b/tests/checkers/test_checkers_terminal_scale.py
@@ -1,0 +1,63 @@
+"""Tests for checkers terminal values across evaluation scales."""
+
+from dataclasses import dataclass
+
+import pytest
+
+pytest.importorskip("valanga")
+from valanga import Color
+
+from chipiron.games.game.game_rules import GameOutcome, OutcomeKind
+from chipiron.players.boardevaluators.evaluation_scale import (
+    EvaluationScale,
+    get_value_over_enum,
+)
+from chipiron.players.evaluators.checkers_piece_count import CheckersOverEventDetector
+
+
+@dataclass(frozen=True)
+class _StubRules:
+    outcome_to_return: GameOutcome
+
+    def outcome(self, state: object) -> GameOutcome:
+        del state
+        return self.outcome_to_return
+
+
+def _value_for_outcome(
+    outcome: GameOutcome, evaluation_scale: EvaluationScale
+) -> float:
+    detector = CheckersOverEventDetector(
+        rules=_StubRules(outcome),
+        value_over_enum=get_value_over_enum(evaluation_scale),
+    )
+    _, value = detector.check_obvious_over_events(state=object())
+    assert value is not None
+    return value
+
+
+@pytest.mark.parametrize(
+    "evaluation_scale",
+    [
+        EvaluationScale.ENTIRE_REAL_AXIS,
+        EvaluationScale.SYMMETRIC_UNIT_INTERVAL,
+    ],
+)
+def test_checkers_terminal_values_match_value_over_enum(
+    evaluation_scale: EvaluationScale,
+) -> None:
+    """Terminal outcomes match values defined by the selected scale enum."""
+    value_over_enum = get_value_over_enum(evaluation_scale)
+
+    assert _value_for_outcome(
+        GameOutcome(kind=OutcomeKind.WIN, winner=Color.WHITE),
+        evaluation_scale,
+    ) == float(value_over_enum.VALUE_WHITE_WHEN_OVER_WHITE_WINS)
+    assert _value_for_outcome(
+        GameOutcome(kind=OutcomeKind.DRAW),
+        evaluation_scale,
+    ) == float(value_over_enum.VALUE_WHITE_WHEN_OVER_DRAW)
+    assert _value_for_outcome(
+        GameOutcome(kind=OutcomeKind.WIN, winner=Color.BLACK),
+        evaluation_scale,
+    ) == float(value_over_enum.VALUE_WHITE_WHEN_OVER_BLACK_WINS)

--- a/tests/checkers/test_checkers_tree_piececount_config.py
+++ b/tests/checkers/test_checkers_tree_piececount_config.py
@@ -1,3 +1,5 @@
+"""Config-loading test for checkers piece-count player."""
+
 import sys
 
 import pytest
@@ -13,11 +15,26 @@ pytestmark = pytest.mark.skipif(
     reason="Config loading in this repository targets Python >= 3.12.",
 )
 def test_checkers_tree_piececount_yaml_loads() -> None:
+    """Checkers config loads with defaults for optional evaluator fields."""
     pytest.importorskip("parsley")
 
+    from chipiron.players.boardevaluators.evaluation_scale import EvaluationScale
+    from chipiron.players.boardevaluators.neural_networks.input_converters.model_input_representation_type import (
+        InternalTensorRepresentationType,
+    )
     from chipiron.players.move_selector.tree_and_value_args import TreeAndValueAppArgs
     from chipiron.players.player_ids import PlayerConfigTag
 
     args = PlayerConfigTag.CHECKERS_TREE_PIECECOUNT.get_players_args()
     assert args.name == "CheckersTreePieceCount"
     assert isinstance(args.main_move_selector, TreeAndValueAppArgs)
+    evaluator_args = args.main_move_selector.evaluator_args
+    assert (
+        evaluator_args.internal_representation_type
+        is InternalTensorRepresentationType.NO
+    )
+    assert evaluator_args.master_board_evaluator.oracle_evaluation is False
+    assert (
+        evaluator_args.master_board_evaluator.evaluation_scale
+        is EvaluationScale.ENTIRE_REAL_AXIS
+    )


### PR DESCRIPTION
### Motivation

- Ensure terminal game outcomes for Checkers produce values consistent with the selected evaluation scale enum rather than hard-coded constants.
- Make some evaluator configuration fields optional and provide sensible defaults so config loading works without requiring every field to be present.
- Wire the chosen `evaluation_scale` through the checkers wiring to the terminal-value detector so different scales produce correct terminal values.

### Description

- `CheckersOverEventDetector` now accepts a `value_over_enum` (`ValueOverEnum`) and maps `OutcomeKind` results to the corresponding enum values instead of hard-coded +/-1/0.
- `checkers_wiring` calls `get_value_over_enum(evaluator_args.evaluation_scale)` and passes the resulting enum into `CheckersOverEventDetector` when building the master evaluator.
- `MasterBoardEvaluatorArgs` was updated to provide defaults (`oracle_evaluation: bool = False`, `evaluation_scale: EvaluationScale = EvaluationScale.ENTIRE_REAL_AXIS`) and to include the `board_evaluator` type annotation earlier in the dataclass.
- `NodeEvaluatorArgs` was relaxed so `internal_representation_type` is optional (`InternalTensorRepresentationType | None = None`) and moved to a trailing field to allow configs that omit it.
- YAML config `CheckersTreePieceCount` was adjusted to use the new string values for the optional fields (e.g. `internal_representation_type: "no"`, `evaluation_scale: "entire_real_axis"`).
- Added tests: `tests/checkers/test_checkers_terminal_scale.py` to verify terminal values match the selected `EvaluationScale`, and `tests/checkers/test_checkers_tree_piececount_config.py` to verify config loading and defaulting behavior.

### Testing

- Ran `tests/checkers/test_checkers_terminal_scale.py` which asserts terminal values come from `get_value_over_enum` for both `EvaluationScale.ENTIRE_REAL_AXIS` and `EvaluationScale.SYMMETRIC_UNIT_INTERVAL`, and the test passed.
- Ran `tests/checkers/test_checkers_tree_piececount_config.py` which loads `CheckersTreePieceCount` config and checks defaulted fields for `internal_representation_type`, `oracle_evaluation`, and `evaluation_scale`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1e2aed1c832b86efabd2ac175080)